### PR TITLE
fix: improve settings window activation to bring to front or open if necessary

### DIFF
--- a/Sources/UI/MenuBar/MenuItemView.swift
+++ b/Sources/UI/MenuBar/MenuItemView.swift
@@ -78,7 +78,9 @@ struct MenuItemView: View {
         .disabled(!appDelegate.updaterController.canCheckForUpdates)
 
         Button {
-            openSettings()
+            SettingsWindowActivation.openOrBringToFront {
+                openSettings()
+            }
         } label: {
             Label("Settings...", systemImage: "gearshape")
         }

--- a/Sources/UI/PopupPanel/PopupView.swift
+++ b/Sources/UI/PopupPanel/PopupView.swift
@@ -126,8 +126,9 @@ struct PopupView: View {
                     )
 
                     Button {
-                        NSApp.activate(ignoringOtherApps: true)
-                        openSettings()
+                        SettingsWindowActivation.openOrBringToFront {
+                            openSettings()
+                        }
                         onOpenSettings?()
                     } label: {
                         Image(systemName: "gearshape")

--- a/Sources/Utilities/SettingsWindowActivation.swift
+++ b/Sources/Utilities/SettingsWindowActivation.swift
@@ -1,0 +1,17 @@
+import AppKit
+
+enum SettingsWindowActivation {
+    @MainActor
+    /// Bring Settings to front if it already exists; otherwise open it via fallback.
+    ///
+    /// We prefer `showPreferencesWindow:` because it reliably focuses an existing
+    /// Settings window. Some contexts may not route that action, so we keep
+    /// `openSettings()` as a fallback for creating/presenting the Settings scene.
+    static func openOrBringToFront(fallbackOpenSettings: () -> Void) {
+        NSApp.activate(ignoringOtherApps: true)
+        let handled = NSApp.sendAction(Selector(("showPreferencesWindow:")), to: nil, from: nil)
+        if !handled {
+            fallbackOpenSettings()
+        }
+    }
+}


### PR DESCRIPTION
### 背景
当 MoePeek 的设置窗口已经存在但被其他窗口遮挡时，点击状态栏菜单的 **“Settings...”**，窗口不会被拉到最前面。  
用户体感像“没有反应”或“按钮失效”。

同时，Popup 面板里的齿轮设置入口也存在与菜单入口行为不一致的风险。

### 根因
设置入口此前主要依赖 `openSettings()`。  
在“设置窗口已存在”的场景下，该调用不一定稳定触发“前置已有窗口”的行为，导致窗口仍被遮挡。

此外，菜单入口与 Popup 入口各自实现，存在逻辑漂移风险。

### 改动内容
- 新增文件：`Sources/Utilities/SettingsWindowActivation.swift`
- 提供统一方法：
  - `SettingsWindowActivation.openOrBringToFront(fallbackOpenSettings:)`
- 统一策略：
  - 先 `NSApp.activate(ignoringOtherApps: true)`
  - 优先发送 `showPreferencesWindow:`（用于前置已有设置窗口）
  - 若 action 未处理，则回退 `openSettings()`（确保可打开/创建设置窗口）

- 替换调用点：
  - `Sources/UI/MenuBar/MenuItemView.swift`
  - `Sources/UI/PopupPanel/PopupView.swift`

### 影响范围
- 仅影响“打开设置窗口”的交互行为（菜单栏入口与 Popup 齿轮入口）。
- 不涉及翻译流程、Provider 请求协议或核心业务状态机。

### 验证
- 静态检查：
  - `SettingsWindowActivation.swift` 无报错
  - `MenuItemView.swift` 无报错
  - `PopupView.swift` 无报错

- 手动验证：
  1. 打开 Settings 窗口并让其被其他应用窗口遮挡；
  2. 点击状态栏菜单 **Settings...**；
  3. 预期：MoePeek 被激活，已有 Settings 窗口被前置。

- 补充验证：
  1. 在 Popup 中点击齿轮按钮；
  2. 预期：行为与菜单入口一致（可前置已有设置窗口，必要时可正常打开设置）。