### PR TITLE
fix: restore reliable settings window activation from menu and popup

### DIFF
--- a/Sources/UI/MenuBar/MenuItemView.swift
+++ b/Sources/UI/MenuBar/MenuItemView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Defaults
 import KeyboardShortcuts
 import SwiftUI
@@ -5,6 +6,7 @@ import SwiftUI
 /// Content for the menu bar dropdown.
 struct MenuItemView: View {
     let appDelegate: AppDelegate
+    @Environment(\.openSettings) private var openSettings
 
     private var appVersion: String {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
@@ -76,7 +78,9 @@ struct MenuItemView: View {
         }
         .disabled(!appDelegate.updaterController.canCheckForUpdates)
 
-        SettingsLink {
+        Button {
+            openSettingsOrBringToFront()
+        } label: {
             Label("Settings...", systemImage: "gearshape")
         }
         .keyboardShortcut(",")
@@ -87,5 +91,14 @@ struct MenuItemView: View {
             NSApplication.shared.terminate(nil)
         }
         .keyboardShortcut("q")
+    }
+
+    @MainActor
+    private func openSettingsOrBringToFront() {
+        NSApp.activate(ignoringOtherApps: true)
+        let handled = NSApp.sendAction(Selector(("showPreferencesWindow:")), to: nil, from: nil)
+        if !handled {
+            openSettings()
+        }
     }
 }

--- a/Sources/UI/PopupPanel/PopupView.swift
+++ b/Sources/UI/PopupPanel/PopupView.swift
@@ -144,15 +144,16 @@ struct PopupView: View {
                         onOpenSettings?()
                         Task { @MainActor in
                             try? await Task.sleep(for: .milliseconds(100))
-                            NSApp.activate()
-                            settingsAction()
+                            openSettingsOrBringToFront {
+                                settingsAction()
+                            }
                             for _ in 0..<10 {
                                 try? await Task.sleep(for: .milliseconds(50))
                                 guard let w = NSApp.windows.first(where: {
                                     !($0 is NSPanel) && $0.styleMask.contains(.titled) && $0.isVisible
                                 }) else { continue }
                                 w.makeKeyAndOrderFront(nil)
-                                NSApp.activate()
+                                NSApp.activate(ignoringOtherApps: true)
                                 break
                             }
                             isOpeningSettings = false
@@ -222,6 +223,15 @@ struct PopupView: View {
                 }
             }
         )
+    }
+
+    @MainActor
+    private func openSettingsOrBringToFront(_ fallbackOpenSettings: () -> Void) {
+        NSApp.activate(ignoringOtherApps: true)
+        let handled = NSApp.sendAction(Selector(("showPreferencesWindow:")), to: nil, from: nil)
+        if !handled {
+            fallbackOpenSettings()
+        }
     }
 }
 


### PR DESCRIPTION
## 变更概述

本 PR 修复了一个回归问题：在以下入口点击 **设置（Settings）** 时，设置窗口有概率无法稳定置前或激活：

- 菜单栏下拉菜单（`MenuItemView`）
- 弹窗面板右上角齿轮按钮（`PopupView`）

该问题在 LSUIElement/accessory 模式与非激活面板（non-activating panel）场景下更明显。

## 问题原因

- 在当前应用架构下，仅依赖 `SettingsLink` 或直接调用 `openSettings()`，并不能保证设置窗口总能被激活并前置。
- 弹窗路径中还存在激活时序竞争（面板关闭、激活策略切换与打开设置窗口之间的 race condition）。

## 具体修改

### 1. `Sources/UI/MenuBar/MenuItemView.swift`

- 将 `SettingsLink` 替换为 `Button`，改为显式“激活 + 打开/置前”流程。
- 新增 `@Environment(\.openSettings)` 作为兜底打开方式。
- 新增辅助方法逻辑：
  - `NSApp.activate(ignoringOtherApps: true)`
  - `NSApp.sendAction(Selector(("showPreferencesWindow:")), to: nil, from: nil)`
  - 若 action 未被处理，则 fallback 到 `openSettings()`

效果：优先将已存在的设置窗口置前；若不存在再创建并打开。

### 2. `Sources/UI/PopupPanel/PopupView.swift`

- 引入与菜单栏一致的“优先置前，失败再打开”策略。
- 保留并强化原有 LSUIElement/accessory 场景处理流程：
  - 必要时切换 activation policy
  - 先关闭弹窗，减少 non-activating panel 干扰
  - 使用 `NSApp.activate(ignoringOtherApps: true)` 提升激活可靠性
  - 继续短轮询已出现的 titled 设置窗口并强制置前

### 影响范围（Diff）

- `Sources/UI/MenuBar/MenuItemView.swift`：`+14 / -1`
- `Sources/UI/PopupPanel/PopupView.swift`：`+13 / -3`

合计：**2 个文件，+27 / -4**

### 预期结果

- 从菜单栏点击 **Settings...** 可稳定打开或置前设置窗口。
- 从弹窗齿轮点击设置可稳定打开或置前，不再“打开了但看不见/没到前台”。
- 若设置窗口已存在，会被复用并前置，而不是无响应。

### 手动验证清单

- [x] 在菜单栏中点击 `Settings...`，确认设置窗口被激活并前置
- [x] 在弹窗齿轮中点击设置，确认设置窗口被激活并前置
- [x] 在 accessory / non-activating 场景下重复验证稳定性
- [x] 设置窗口已存在时再次触发，确认能正确置前
### 备注

- 当前仓库未配置自动化测试框架，本次通过手动回归验证。
- 本次修改范围刻意收敛，仅针对设置窗口激活与置前可靠性问题。