### PR TITLE
feat: add model search functionality and localization support

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -1044,6 +1044,16 @@
         }
       }
     },
+    "No models match your search." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有匹配的模型。"
+          }
+        }
+      }
+    },
     "No Preference" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -1480,6 +1490,16 @@
     },
     "Secret Key" : {
 
+    },
+    "Search models…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索模型…"
+          }
+        }
+      }
     },
     "Select a model" : {
       "localizations" : {


### PR DESCRIPTION
### 概述
在「服务 → 模型配置 → 并行模型」中增加搜索框，支持按关键字过滤可选模型，便于在大量模型中快速查找。

### 改动说明

**涉及文件：**
- `Sources/Services/Providers/OpenAIConfigFields.swift` — OpenAI 兼容 API 的并行模型配置
- `Sources/Services/Providers/LocalLLMSettingsView.swift` — LM Studio / Ollama 的并行模型配置
- `Resources/Localizable.xcstrings` — 新增文案本地化

**实现要点：**
- 在并行模型列表上方增加搜索输入框
- 按关键字过滤模型（不区分大小写、子串匹配）
- 搜索无结果时显示「没有匹配的模型。」
- 支持中英文文案（"Search models…" / "搜索模型…"）

### 使用方式
1. 打开 **设置 → 服务**，选择任意翻译服务
2. 进入 **模型配置**，在 **并行模型** 区域
3. 当有可选模型时，在列表上方会出现搜索框
4. 输入关键字即可过滤并快速定位模型

### 截图
<img width="1744" height="1720" alt="CleanShot 2026-02-25 at 22 20 13@2x" src="https://github.com/user-attachments/assets/c899d77b-d25f-47c6-8608-d39243a67ca5" />
