### PR TITLE
refactor(MenuBar): use globalKeyboardShortcut for menu items instead of hardcoded shortcuts

### DIFF
--- a/Sources/UI/MenuBar/MenuItemView.swift
+++ b/Sources/UI/MenuBar/MenuItemView.swift
@@ -26,7 +26,7 @@ struct MenuItemView: View {
         } label: {
             Label("Manual Translation", systemImage: "keyboard")
         }
-        .keyboardShortcut("a", modifiers: .option)
+        .globalKeyboardShortcut(.inputTranslation)
 
         Button {
             guard let coordinator = appDelegate.coordinator,
@@ -39,7 +39,7 @@ struct MenuItemView: View {
         } label: {
             Label("Screenshot OCR", systemImage: "text.viewfinder")
         }
-        .keyboardShortcut("s", modifiers: .option)
+        .globalKeyboardShortcut(.ocrScreenshot)
 
         Button {
             guard let coordinator = appDelegate.coordinator,
@@ -51,7 +51,7 @@ struct MenuItemView: View {
         } label: {
             Label("Selection Translation", systemImage: "text.cursor")
         }
-        .keyboardShortcut("d", modifiers: .option)
+        .globalKeyboardShortcut(.translateSelection)
 
         Button {
             guard let coordinator = appDelegate.coordinator,
@@ -61,7 +61,7 @@ struct MenuItemView: View {
         } label: {
             Label("Clipboard Translation", systemImage: "doc.on.clipboard")
         }
-        .keyboardShortcut("v", modifiers: .option)
+        .globalKeyboardShortcut(.clipboardTranslation)
 
         Divider()
 


### PR DESCRIPTION
### 问题描述

ref #25 

菜单栏下拉菜单中的「Manual Translation」「Screenshot OCR」「Selection Translation」「Clipboard Translation」四个入口，此前使用硬编码快捷键（⌥A、⌥S、⌥D、⌥V），与用户在设置中配置的全局快捷键不一致。用户在设置中修改快捷键后，菜单旁仍显示默认值，容易造成混淆。

### 修复方式

将 `MenuItemView` 中四个菜单按钮的 `.keyboardShortcut("x", modifiers: .option)` 替换为 `.globalKeyboardShortcut(.xxx)`，使其从 `Constants.swift` 中定义的 `KeyboardShortcuts.Name` 读取当前配置，与全局快捷键注册保持一致。

**涉及文件：**
- `Sources/UI/MenuBar/MenuItemView.swift`：4 处修改

| 菜单项 | 修改前 | 修改后 |
|--------|--------|--------|
| Manual Translation | `.keyboardShortcut("a", modifiers: .option)` | `.globalKeyboardShortcut(.inputTranslation)` |
| Screenshot OCR | `.keyboardShortcut("s", modifiers: .option)` | `.globalKeyboardShortcut(.ocrScreenshot)` |
| Selection Translation | `.keyboardShortcut("d", modifiers: .option)` | `.globalKeyboardShortcut(.translateSelection)` |
| Clipboard Translation | `.keyboardShortcut("v", modifiers: .option)` | `.globalKeyboardShortcut(.clipboardTranslation)` |

### 测试说明

1. 打开 MoePeek 设置，修改任意翻译相关快捷键（如将「选择翻译」改为 ⌥T）
2. 点击菜单栏图标，查看下拉菜单
3. 确认对应菜单项旁显示的快捷键与设置中一致