### PR TITLE
fix: avoid triggering translate on Enter during IME composition

### DIFF
--- a/Sources/UI/PopupPanel/SourceInputView.swift
+++ b/Sources/UI/PopupPanel/SourceInputView.swift
@@ -114,7 +114,9 @@ private final class SubmitAwareTextView: NSTextView {
         let isReturnKey = event.keyCode == 36 || event.keyCode == 76
         let hasShift = event.modifierFlags.contains(.shift)
 
-        if isReturnKey, !hasShift {
+        // During IME composition (e.g. Chinese Pinyin), Enter should first commit marked text.
+        // Only submit translation when composition has ended.
+        if isReturnKey, !hasShift, !hasMarkedText() {
             onSubmit?()
             return
         }


### PR DESCRIPTION
## Summary
- prevent Enter from submitting translation while IME composition is active
- allow first Enter to commit marked text (e.g. Chinese Pinyin candidate)
- only trigger translation on Enter when no marked text is present

## Change
- update `SubmitAwareTextView.keyDown(with:)` in `Sources/UI/PopupPanel/SourceInputView.swift`
- add `!hasMarkedText()` guard to Enter submit condition

## Why
When using Chinese IME, the first Enter should commit composition text, but the app currently intercepts Enter and triggers translation too early, leading to "文本为空".

## Manual test
1. Switch to Chinese Pinyin IME
2. Type `sorry` in source input
3. Press Enter once: candidate is committed, translation is **not** triggered
4. Press Enter again: translation is triggered
5. Verify normal Enter behavior in non-IME mode remains unchanged
