### PR TITLE
feat(ParallelModels): add split-section UI with locked default model for parallel model selection

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -1,6 +1,16 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "(default)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "（默认）"
+          }
+        }
+      }
+    },
     "(unknown)" : {
       "localizations" : {
         "zh-Hans" : {
@@ -116,6 +126,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "应用更新后，macOS 可能会撤销之前授予的权限。请在下方重新授权。"
+          }
+        }
+      }
+    },
+    "All Models" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部模型"
           }
         }
       }
@@ -362,6 +382,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "检查中…"
+          }
+        }
+      }
+    },
+    "Clear All" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部清除"
           }
         }
       }
@@ -1654,6 +1684,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "选择翻译服务"
+          }
+        }
+      }
+    },
+    "Selected" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已选模型"
           }
         }
       }

--- a/Sources/Services/Providers/AnthropicProvider.swift
+++ b/Sources/Services/Providers/AnthropicProvider.swift
@@ -8,7 +8,7 @@ import SwiftUI
 /// - System prompt as top-level `system` field (not in messages array)
 /// - `max_tokens` is required
 /// - Different SSE event format
-struct AnthropicProvider: TranslationProvider {
+struct AnthropicProvider: ParallelModelProvider {
     static let apiVersion = "2023-06-01"
 
     let id = "anthropic"
@@ -28,11 +28,6 @@ struct AnthropicProvider: TranslationProvider {
         default: "Translate the following text to {targetLang}. Only output the translation, nothing else."
     )
     let maxTokensKey = Defaults.Key<Int>("provider_anthropic_maxTokens", default: 4096)
-
-    var activeModels: [String] {
-        let enabled = Defaults[enabledModelsKey]
-        return enabled.isEmpty ? [] : enabled.sorted()
-    }
 
     @MainActor
     var isConfigured: Bool {

--- a/Sources/Services/Providers/AnthropicSettingsView.swift
+++ b/Sources/Services/Providers/AnthropicSettingsView.swift
@@ -209,7 +209,8 @@ struct AnthropicSettingsView: View {
         ParallelModelsList(
             fetchedModels: connectionManager.fetchedModels,
             enabledModels: enabledModels,
-            metaService: metaService
+            metaService: metaService,
+            defaultModel: modelText
         )
     }
 }

--- a/Sources/Services/Providers/LMStudioProvider.swift
+++ b/Sources/Services/Providers/LMStudioProvider.swift
@@ -4,7 +4,7 @@ import SwiftUI
 
 /// LM Studio local LLM provider. Uses OpenAI-compatible API endpoints
 /// (default: http://localhost:1234/v1). No API key required.
-struct LMStudioProvider: TranslationProvider {
+struct LMStudioProvider: ParallelModelProvider {
     let id = "lmstudio"
     let displayName = "LM Studio"
     let iconSystemName = "cpu"
@@ -19,11 +19,6 @@ struct LMStudioProvider: TranslationProvider {
         "provider_lmstudio_systemPrompt",
         default: "Translate the following text to {targetLang}. Only output the translation, nothing else."
     )
-
-    var activeModels: [String] {
-        let enabled = Defaults[enabledModelsKey]
-        return enabled.isEmpty ? [] : enabled.sorted()
-    }
 
     var resolvedBaseURL: String {
         Defaults[baseURLKey].trimmingCharacters(in: CharacterSet(charactersIn: "/"))

--- a/Sources/Services/Providers/OllamaProvider.swift
+++ b/Sources/Services/Providers/OllamaProvider.swift
@@ -4,7 +4,7 @@ import SwiftUI
 
 /// Ollama local LLM provider. Uses Ollama's native API for model listing
 /// and OpenAI-compatible endpoint for translation.
-struct OllamaProvider: TranslationProvider {
+struct OllamaProvider: ParallelModelProvider {
     let id = "ollama"
     let displayName = "Ollama"
     let iconSystemName = "desktopcomputer"
@@ -19,12 +19,6 @@ struct OllamaProvider: TranslationProvider {
         "provider_ollama_systemPrompt",
         default: "Translate the following text to {targetLang}. Only output the translation, nothing else."
     )
-
-    /// Models explicitly enabled for parallel translation. Empty means use default single model.
-    var activeModels: [String] {
-        let enabled = Defaults[enabledModelsKey]
-        return enabled.isEmpty ? [] : enabled.sorted()
-    }
 
     var resolvedBaseURL: String {
         Defaults[baseURLKey].trimmingCharacters(in: CharacterSet(charactersIn: "/"))

--- a/Sources/Services/Providers/OpenAICompatibleProvider.swift
+++ b/Sources/Services/Providers/OpenAICompatibleProvider.swift
@@ -3,7 +3,7 @@ import Foundation
 import SwiftUI
 
 /// A parameterized provider for any OpenAI-compatible API (OpenAI, DeepSeek, etc.).
-struct OpenAICompatibleProvider: TranslationProvider {
+struct OpenAICompatibleProvider: ParallelModelProvider {
     let id: String
     let displayName: String
     let iconSystemName: String
@@ -25,12 +25,6 @@ struct OpenAICompatibleProvider: TranslationProvider {
     let systemPromptKey: Defaults.Key<String>
     let apiKeyKey: Defaults.Key<String>
     let guideURL: String?
-
-    /// Models explicitly enabled for parallel translation. Empty means use default single model.
-    var activeModels: [String] {
-        let enabled = Defaults[enabledModelsKey]
-        return enabled.isEmpty ? [] : enabled.sorted()
-    }
 
     /// All UserDefaults suffixes used by this provider type.
     private static let defaultsSuffixes = ["baseURL", "apiKey", "model", "enabledModels", "systemPrompt"]

--- a/Sources/Services/Providers/OpenAIConfigFields.swift
+++ b/Sources/Services/Providers/OpenAIConfigFields.swift
@@ -117,7 +117,8 @@ struct OpenAIConfigFields: View {
                     ParallelModelsList(
                         fetchedModels: filteredModels,
                         enabledModels: enabledModels,
-                        metaService: metaService
+                        metaService: metaService,
+                        defaultModel: modelText
                     )
                 }
             }
@@ -177,17 +178,31 @@ struct ModelCheckboxRow: View {
     let isEnabled: Bool
     let isUnknown: Bool
     let isDisabled: Bool
+    var isDefault: Bool = false
     var metaMatch: ModelMetadataService.MetaMatch? = nil
     let onToggle: () -> Void
 
     var body: some View {
         Button(action: onToggle) {
             HStack(spacing: 6) {
-                Image(systemName: isEnabled ? "checkmark.square.fill" : "square")
-                    .foregroundStyle(isEnabled ? Color.accentColor : .secondary)
+                if isDefault {
+                    Image(systemName: "checkmark.square.fill")
+                        .foregroundStyle(.secondary)
+                } else {
+                    Image(systemName: isEnabled ? "checkmark.square.fill" : "square")
+                        .foregroundStyle(isEnabled ? Color.accentColor : .secondary)
+                }
                 Text(modelID)
                     .lineLimit(1)
-                if isUnknown && metaMatch == nil {
+                if isDefault {
+                    Text("(default)")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Image(systemName: "lock.fill")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                if isUnknown && metaMatch == nil && !isDefault {
                     Text("(unknown)")
                         .font(.caption2)
                         .foregroundStyle(.orange)
@@ -200,7 +215,7 @@ struct ModelCheckboxRow: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .disabled(isDisabled)
+        .disabled(isDisabled || isDefault)
         .opacity(isDisabled ? 0.5 : 1)
         .padding(.vertical, 2)
         .padding(.horizontal, 4)

--- a/Sources/Services/Providers/ParallelModelsList.swift
+++ b/Sources/Services/Providers/ParallelModelsList.swift
@@ -2,15 +2,27 @@ import SwiftUI
 
 /// Reusable parallel model selection list with search, toggle, and custom model input.
 /// Shared between OpenAIConfigFields and AnthropicSettingsView.
+///
+/// Layout: Selected section (default model locked + user-picked models) above
+/// the full All Models list where checked items remain visible for comparison.
 struct ParallelModelsList: View {
     /// All fetched model IDs (already sorted/filtered by caller).
     let fetchedModels: [String]
-    /// Binding to the set of user-enabled model IDs.
+    /// Binding to the set of user-enabled model IDs (excludes default model).
     @Binding var enabledModels: Set<String>
     let metaService: ModelMetadataService
+    /// Current default model ID — always shown as checked & locked.
+    let defaultModel: String
 
     @State private var modelSearchQuery = ""
     @State private var customModelInput = ""
+
+    /// Whether the default model appears in the available list.
+    private var defaultModelInList: Bool {
+        let trimmed = defaultModel.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return false }
+        return fetchedModels.contains(trimmed) || enabledModels.contains(trimmed)
+    }
 
     /// All model IDs to display: fetched models + enabled but not in fetch list.
     private var displayModels: [String] {
@@ -25,8 +37,19 @@ struct ParallelModelsList: View {
         return displayModels.filter { $0.lowercased().contains(query) }
     }
 
+    /// Models explicitly selected by the user (excluding the default model).
+    private var selectedModels: [String] {
+        enabledModels.subtracting([defaultModel]).sorted()
+    }
+
+    /// Whether the "Selected" section should be visible.
+    private var hasSelectedSection: Bool {
+        defaultModelInList || !selectedModels.isEmpty
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
+            // Header
             HStack {
                 Text("Select models to run in parallel during translation.")
                     .font(.caption)
@@ -41,12 +64,54 @@ struct ParallelModelsList: View {
                 }
             }
 
+            // MARK: - Selected Section
+            if hasSelectedSection {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Selected")
+                        .font(.caption.bold())
+                        .foregroundStyle(.secondary)
+                        .padding(.top, 4)
+
+                    if defaultModelInList {
+                        ModelCheckboxRow(
+                            modelID: defaultModel,
+                            isEnabled: true,
+                            isUnknown: false,
+                            isDisabled: false,
+                            isDefault: true,
+                            metaMatch: metaService.meta(for: defaultModel),
+                            onToggle: {}
+                        )
+                    }
+
+                    ForEach(selectedModels, id: \.self) { modelID in
+                        ModelCheckboxRow(
+                            modelID: modelID,
+                            isEnabled: true,
+                            isUnknown: !fetchedModels.contains(modelID),
+                            isDisabled: false,
+                            metaMatch: metaService.meta(for: modelID),
+                            onToggle: { toggleModel(modelID) }
+                        )
+                    }
+                }
+
+                Divider()
+            }
+
+            // MARK: - All Models Section
             if displayModels.isEmpty {
                 Text("Click the refresh button above to fetch available models, or add a custom model below.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .padding(.vertical, 4)
             } else {
+                if hasSelectedSection {
+                    Text("All Models")
+                        .font(.caption.bold())
+                        .foregroundStyle(.secondary)
+                }
+
                 TextField("Search models…", text: $modelSearchQuery)
                     .textFieldStyle(.roundedBorder)
 
@@ -59,13 +124,15 @@ struct ParallelModelsList: View {
                     ScrollView {
                         VStack(alignment: .leading, spacing: 2) {
                             ForEach(searchFilteredModels, id: \.self) { modelID in
+                                let isDefaultRow = modelID == defaultModel && defaultModelInList
                                 ModelCheckboxRow(
                                     modelID: modelID,
-                                    isEnabled: enabledModels.contains(modelID),
-                                    isUnknown: !fetchedModels.contains(modelID),
-                                    isDisabled: !enabledModels.contains(modelID) && enabledModels.count >= maxParallelModels,
+                                    isEnabled: enabledModels.contains(modelID) || isDefaultRow,
+                                    isUnknown: !fetchedModels.contains(modelID) && !isDefaultRow,
+                                    isDisabled: !enabledModels.contains(modelID) && !isDefaultRow && enabledModels.count >= maxParallelModels,
+                                    isDefault: isDefaultRow,
                                     metaMatch: metaService.meta(for: modelID),
-                                    onToggle: { toggleModel(modelID) }
+                                    onToggle: { if !isDefaultRow { toggleModel(modelID) } }
                                 )
                             }
                         }
@@ -89,9 +156,9 @@ struct ParallelModelsList: View {
                 .disabled(customModelInput.trimmingCharacters(in: .whitespaces).isEmpty || enabledModels.count >= maxParallelModels)
             }
 
-            let count = enabledModels.count
-            if count > 0 {
-                Text("\(count) model(s) enabled — will run in parallel during translation.")
+            let totalCount = enabledModels.subtracting([defaultModel]).count + (defaultModelInList ? 1 : 0)
+            if totalCount > 0 {
+                Text("\(totalCount) model(s) enabled — will run in parallel during translation.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -107,9 +174,21 @@ struct ParallelModelsList: View {
                 }
             }
         }
+        .onAppear {
+            // Clean up: remove default model from enabledModels if present (it's implicit now)
+            if enabledModels.contains(defaultModel) {
+                enabledModels.remove(defaultModel)
+            }
+        }
+        .onChange(of: defaultModel) { _, newDefault in
+            if enabledModels.contains(newDefault) {
+                enabledModels.remove(newDefault)
+            }
+        }
     }
 
     private func toggleModel(_ modelID: String) {
+        guard modelID != defaultModel else { return }
         if enabledModels.contains(modelID) {
             enabledModels.remove(modelID)
         } else {
@@ -120,7 +199,7 @@ struct ParallelModelsList: View {
 
     private func addCustomModel() {
         let trimmed = customModelInput.trimmingCharacters(in: .whitespaces)
-        guard !trimmed.isEmpty, enabledModels.count < maxParallelModels else { return }
+        guard !trimmed.isEmpty, trimmed != defaultModel, enabledModels.count < maxParallelModels else { return }
         enabledModels.insert(trimmed)
         customModelInput = ""
     }


### PR DESCRIPTION
### 概述

优化并行翻译模型选择界面，将模型列表拆分为"已选模型"和"全部模型"两个分区，使已勾选模型始终可见。同时将默认模型自动纳入并行翻译，并在 UI 上以锁定状态展示，避免用户意外取消。

### 改动说明

**新增 `ParallelModelProvider` 协议（`TranslationProvider.swift`）**
- 提取 4 个 Provider（Anthropic、LMStudio、Ollama、OpenAICompatible）中重复的 `activeModels` 计算逻辑为统一协议扩展
- 新逻辑：当 `enabledModels` 非空时，自动将默认模型加入 `activeModels` 集合

**拆分模型列表 UI（`ParallelModelsList.swift`）**
- 顶部"已选模型"分区：展示锁定的默认模型 + 用户手动勾选的模型
- 底部"全部模型"分区：完整模型列表，支持搜索和勾选
- 默认模型在切换时自动从 `enabledModels` 中清理（它是隐式包含的）
- 自定义模型输入时阻止添加与默认模型相同的 ID

**默认模型锁定 UI（`OpenAIConfigFields.swift`）**
- `ModelCheckboxRow` 新增 `isDefault` 属性，渲染为灰色勾选 + "(default)" 标签 + 锁图标
- 默认模型行禁用交互，防止误操作

**国际化（`Localizable.xcstrings`）**
- 新增 4 条中文翻译："(default)"、"All Models"、"Clear All"、"Selected"

### 使用方式

1. 在任意翻译服务设置中，点击刷新获取模型列表
2. 默认模型（即主模型设置中选择的模型）自动出现在"已选模型"分区顶部，带锁定标识
3. 在"全部模型"列表中勾选其他模型，被选中的模型会同时出现在顶部"已选模型"分区
4. 翻译时，默认模型 + 勾选模型将并行执行翻译

<img width="2204" height="1740" alt="CleanShot 2026-02-26 at 18 25 23@2x" src="https://github.com/user-attachments/assets/be8ac8f6-68b4-43ce-8754-d971c951a3f9" />
