### PR TITLE
fix(text-selection): prevent non-text selection false positives

### DIFF
--- a/Sources/Core/TextSelection/ClipboardGrabber.swift
+++ b/Sources/Core/TextSelection/ClipboardGrabber.swift
@@ -62,6 +62,13 @@ enum ClipboardGrabber {
         }
 
         let postCopyCount = pasteboard.changeCount
+
+        // File selections (e.g. Finder items) may put file URLs on the pasteboard;
+        // these are not text selections and should not trigger the floating icon.
+        if pasteboard.canReadObject(forClasses: [NSURL.self], options: nil) {
+            return nil
+        }
+
         let text = pasteboard.string(forType: .string)
 
         // 30ms grace period: if the user's real ⌘+C arrives slightly after our polling


### PR DESCRIPTION
### 问题
- 选择文件/列表项时，部分路径会被误识别为“有文本被选中”，导致触发悬浮图标或后续翻译流程。

### 方案
- 在 `AccessibilityGrabber` 中新增 `selectedTextRange` 非空校验，仅对真实文本范围继续处理。
- 在 `ClipboardGrabber` 中检测剪贴板文件 URL，命中时直接返回。
- 在 `SelectionMonitor` 中：
  - Finder 前台时跳过 fallback tiers；
  - 在“mouse-up 后剪贴板已变化”分支补充文件 URL 保护。

### 影响范围
- `Sources/Core/TextSelection/AccessibilityGrabber.swift`
- `Sources/Core/TextSelection/ClipboardGrabber.swift`
- `Sources/Core/TextSelection/SelectionMonitor.swift`

### 风险与兼容性
- 低风险，主要是增加防误判保护。
- 个别应用若不提供标准 `selectedTextRange`，可能比以前更保守（宁可不触发，也不误触发）。

### 测试建议
- 在 Finder（桌面/列表）选择文件：不应触发文本选择流程。
- 在普通文本编辑器选择文本：应保持原有触发行为。
- 在 Safari/支持 AX 的应用中验证 fallback 行为不回归。