### PR TITLE
fix(text-selection): prevent non-text selection false positives in Finder

### DIFF
--- a/Sources/Core/TextSelection/AccessibilityGrabber.swift
+++ b/Sources/Core/TextSelection/AccessibilityGrabber.swift
@@ -29,11 +29,6 @@ enum AccessibilityGrabber {
         // Safe: CFGetTypeID verified above; as?/as! cannot express CF type casts cleanly.
         let focusedElement = unsafeBitCast(focusedRef, to: AXUIElement.self)
 
-        // Require a concrete text range. This filters out non-text selections
-        // (e.g. selected files/items in list views) that may still expose
-        // a string-like selected value via AX.
-        guard hasNonEmptySelectedTextRange(focusedElement) else { return nil }
-
         var selectedValue: CFTypeRef?
         let selectResult = AXUIElementCopyAttributeValue(
             focusedElement,
@@ -80,28 +75,5 @@ enum AccessibilityGrabber {
         }
 
         return text
-    }
-
-    @MainActor
-    private static func hasNonEmptySelectedTextRange(_ element: AXUIElement) -> Bool {
-        var rangeValue: CFTypeRef?
-        let rangeResult = AXUIElementCopyAttributeValue(
-            element,
-            kAXSelectedTextRangeAttribute as CFString,
-            &rangeValue
-        )
-
-        guard rangeResult == .success,
-              let rangeRef = rangeValue,
-              CFGetTypeID(rangeRef) == AXValueGetTypeID()
-        else { return false }
-
-        let axRangeValue = rangeRef as! AXValue
-        guard AXValueGetType(axRangeValue) == .cfRange else { return false }
-
-        var range = CFRange(location: 0, length: 0)
-        guard AXValueGetValue(axRangeValue, .cfRange, &range) else { return false }
-
-        return range.length > 0
     }
 }

--- a/Sources/Core/TextSelection/ClipboardGrabber.swift
+++ b/Sources/Core/TextSelection/ClipboardGrabber.swift
@@ -63,13 +63,14 @@ enum ClipboardGrabber {
 
         let postCopyCount = pasteboard.changeCount
 
-        // File selections (e.g. Finder items) may put file URLs on the pasteboard;
-        // these are not text selections and should not trigger the floating icon.
-        if pasteboard.canReadObject(forClasses: [NSURL.self], options: nil) {
-            return nil
-        }
+        // Detect file URLs (e.g. Finder items) — only match file:// URLs,
+        // not web URLs which may accompany normal text copies.
+        let isFileSelection = pasteboard.canReadObject(
+            forClasses: [NSURL.self],
+            options: [.urlReadingFileURLsOnly: true]
+        )
 
-        let text = pasteboard.string(forType: .string)
+        let text = isFileSelection ? nil : pasteboard.string(forType: .string)
 
         // 30ms grace period: if the user's real ⌘+C arrives slightly after our polling
         // finishes, the changeCount will bump again.

--- a/Sources/Core/TextSelection/SelectionMonitor.swift
+++ b/Sources/Core/TextSelection/SelectionMonitor.swift
@@ -103,11 +103,7 @@ final class SelectionMonitor {
             // Only attempt fallback tiers if the gesture looks like a selection
             guard wasDragOrMultiClick else { return }
 
-                // Finder file/item selections are not text selections. Skip fallback tiers
-                // (especially clipboard simulation) to avoid false positives on desktop/file views.
-                guard !isFinderFrontmost else { return }
-
-            // Tier 2: AppleScript — Safari-specific JS selection
+            // Tier 2: AppleScript — Safari-specific JS selection (Finder won't match)
             if let text = await AppleScriptGrabber.grabFromSafari(),
                !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 self.onTextSelected?(text, point)
@@ -116,11 +112,16 @@ final class SelectionMonitor {
 
             guard !Task.isCancelled else { return }
 
+            // Finder file/item drag gestures should not trigger clipboard-based detection.
+            // Tier 1 (AX) already handles Finder correctly (file rows don't expose text attributes).
+            // This guard prevents Tier 3 clipboard simulation from copying file paths.
+            guard !isFinderFrontmost else { return }
+
             // Short-circuit before Tier 3: if the clipboard changed since mouse-up,
             // the user already pressed ⌘+C — read directly without simulating another copy.
             if NSPasteboard.general.changeCount != clipboardCountAtMouseUp {
                 // If the clipboard currently contains file URLs, treat it as non-text selection.
-                if NSPasteboard.general.canReadObject(forClasses: [NSURL.self], options: nil) {
+                if NSPasteboard.general.canReadObject(forClasses: [NSURL.self], options: [.urlReadingFileURLsOnly: true]) {
                     return
                 }
 


### PR DESCRIPTION
## Summary

- Finder 中拖拽/选择文件时，不再错误触发文本翻译流程
- ClipboardGrabber 增加 file URL 检测，剪贴板含文件路径时返回 nil
- SelectionMonitor 在进入 Tier 3（剪贴板模拟）前短路 Finder 场景，并在剪贴板变更快捷路径中过滤文件 URL