### PR TITLE
feat: 输入翻译焦点 + Provider 排序设置 + 空输入处理

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -595,6 +595,16 @@
         }
       }
     },
+    "Drag to reorder. This controls the display order of translation results." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拖拽以调整顺序。此设置控制翻译结果的显示顺序。"
+          }
+        }
+      }
+    },
     "Empty text" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -602,6 +612,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "文本为空"
+          }
+        }
+      }
+    },
+    "Enable at least one provider in the Services tab to configure display order." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请在\"服务\"标签页中启用至少一个服务以配置显示顺序。"
           }
         }
       }
@@ -1156,6 +1176,17 @@
         }
       }
     },
+    "No Providers Enabled" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未启用任何服务"
+          }
+        }
+      }
+    },
     "No providers enabled. Enable at least one in Settings." : {
       "extractionState" : "stale",
       "localizations" : {
@@ -1299,6 +1330,17 @@
         }
       }
     },
+    "Order" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "排序"
+          }
+        }
+      }
+    },
     "Parallel Models" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -1402,6 +1444,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "保护您的自托管 DeepLX 服务器。通过 `--token` 标志或 `TOKEN` 环境变量设置。"
+          }
+        }
+      }
+    },
+    "Provider Display Order" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "服务显示顺序"
           }
         }
       }

--- a/Sources/Services/TranslationProviderRegistry.swift
+++ b/Sources/Services/TranslationProviderRegistry.swift
@@ -21,20 +21,39 @@ final class TranslationProviderRegistry {
     /// Enabled providers expanded into per-model slots.
     /// Multi-model providers yield one `ModelSlotProvider` per active model;
     /// single-model providers pass through unchanged (preserving their original id).
+    /// Order respects `providerOrder` user preference; unordered providers append at end.
     var enabledSlots: [any TranslationProvider] {
         let ids = Defaults[.enabledProviders]
-        var result: [any TranslationProvider] = []
-        for provider in providers where ids.contains(provider.id) {
-            let models = provider.activeModels
-            if models.isEmpty {
-                result.append(provider)
-            } else {
-                for model in models.prefix(maxParallelModels) {
-                    result.append(ModelSlotProvider(inner: provider, modelOverride: model))
-                }
+        let enabledProviders = providers.filter { ids.contains($0.id) }
+
+        // Build ordered list: providerOrder first, then remaining by registration order
+        let order = Defaults[.providerOrder]
+        var seen = Set<String>()
+        var ordered: [any TranslationProvider] = []
+
+        for id in order {
+            if let provider = enabledProviders.first(where: { $0.id == id }) {
+                appendSlots(for: provider, to: &ordered)
+                seen.insert(id)
             }
         }
-        return result
+        for provider in enabledProviders where !seen.contains(provider.id) {
+            appendSlots(for: provider, to: &ordered)
+        }
+
+        return ordered
+    }
+
+    /// Expand a single provider into its model slots and append to the result array.
+    private func appendSlots(for provider: any TranslationProvider, to result: inout [any TranslationProvider]) {
+        let models = provider.activeModels
+        if models.isEmpty {
+            result.append(provider)
+        } else {
+            for model in models.prefix(maxParallelModels) {
+                result.append(ModelSlotProvider(inner: provider, modelOverride: model))
+            }
+        }
     }
 
     func provider(withID id: String) -> (any TranslationProvider)? {
@@ -71,6 +90,7 @@ final class TranslationProviderRegistry {
         var enabled = Defaults[.enabledProviders]
         enabled.remove(id)
         Defaults[.enabledProviders] = enabled
+        Defaults[.providerOrder].removeAll { $0 == id }
         OpenAICompatibleProvider.cleanupDefaults(for: id)
         providers.removeAll { $0.id == id }
     }

--- a/Sources/UI/PopupPanel/PopupPanelController.swift
+++ b/Sources/UI/PopupPanel/PopupPanelController.swift
@@ -52,7 +52,10 @@ final class PopupPanelController {
             y: visibleFrame.midY - initialSize.height / 2
         )
         panel.setFrame(NSRect(origin: origin, size: initialSize), display: true)
-        // Input mode needs key window status so the TextEditor receives keyboard focus.
+        // Input mode needs the app activated so the panel can receive keyboard events.
+        // Without this, makeKeyAndOrderFront alone won't route keystrokes to our panel
+        // because macOS keeps delivering them to the previously active app.
+        NSApp.activate(ignoringOtherApps: true)
         panel.makeKeyAndOrderFront(nil)
 
         startDismissMonitor()

--- a/Sources/UI/PopupPanel/SourceInputView.swift
+++ b/Sources/UI/PopupPanel/SourceInputView.swift
@@ -121,6 +121,7 @@ private final class SubmitAwareTextView: NSTextView {
         // During IME composition (e.g. Chinese Pinyin), Enter should first commit marked text.
         // Only submit translation when composition has ended.
         if isReturnKey, !hasShift, !hasMarkedText() {
+            guard !string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
             onSubmit?()
             return
         }

--- a/Sources/UI/Settings/ProviderOrderSettingsView.swift
+++ b/Sources/UI/Settings/ProviderOrderSettingsView.swift
@@ -1,0 +1,85 @@
+import Defaults
+import SwiftUI
+
+/// Settings view for reordering enabled translation providers via drag-and-drop.
+struct ProviderOrderSettingsView: View {
+    let registry: TranslationProviderRegistry
+
+    @Default(.enabledProviders) private var enabledProviders
+    @Default(.providerOrder) private var providerOrder
+
+    /// Enabled providers sorted by the user's preferred order.
+    private var orderedProviders: [any TranslationProvider] {
+        let enabled = registry.providers.filter { enabledProviders.contains($0.id) }
+        var seen = Set<String>()
+        var result: [any TranslationProvider] = []
+
+        for id in providerOrder {
+            if let provider = enabled.first(where: { $0.id == id }) {
+                result.append(provider)
+                seen.insert(id)
+            }
+        }
+        for provider in enabled where !seen.contains(provider.id) {
+            result.append(provider)
+        }
+
+        return result
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("Provider Display Order")
+                .font(.headline)
+                .padding(.horizontal, 20)
+                .padding(.top, 20)
+                .padding(.bottom, 4)
+
+            Text("Drag to reorder. This controls the display order of translation results.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 20)
+                .padding(.bottom, 12)
+
+            if orderedProviders.isEmpty {
+                ContentUnavailableView(
+                    "No Providers Enabled",
+                    systemImage: "globe",
+                    description: Text("Enable at least one provider in the Services tab to configure display order.")
+                )
+            } else {
+                List {
+                    ForEach(orderedProviders, id: \.id) { provider in
+                        HStack(spacing: 10) {
+                            Image(systemName: "line.3.horizontal")
+                                .foregroundStyle(.tertiary)
+                                .font(.callout)
+
+                            ProviderIconView(provider: provider, size: 18)
+
+                            Text(provider.displayName)
+                                .font(.body)
+
+                            Spacer()
+                        }
+                        .padding(.vertical, 2)
+                    }
+                    .onMove { source, destination in
+                        moveProviders(from: source, to: destination)
+                    }
+                }
+                .listStyle(.inset(alternatesRowBackgrounds: true))
+                .scrollContentBackground(.hidden)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    // MARK: - Helpers
+
+    private func moveProviders(from source: IndexSet, to destination: Int) {
+        var ids = orderedProviders.map(\.id)
+        ids.move(fromOffsets: source, toOffset: destination)
+        providerOrder = ids
+    }
+}

--- a/Sources/UI/Settings/ServiceSettingsView.swift
+++ b/Sources/UI/Settings/ServiceSettingsView.swift
@@ -161,8 +161,13 @@ struct ServiceSettingsView: View {
             set: { isEnabled in
                 if isEnabled {
                     enabledProviders.insert(id)
+                    // Append to order list so newly enabled providers appear at the end
+                    if !Defaults[.providerOrder].contains(id) {
+                        Defaults[.providerOrder].append(id)
+                    }
                 } else {
                     enabledProviders.remove(id)
+                    Defaults[.providerOrder].removeAll { $0 == id }
                 }
             }
         )

--- a/Sources/UI/Settings/SettingsView.swift
+++ b/Sources/UI/Settings/SettingsView.swift
@@ -11,6 +11,7 @@ struct SettingsView: View {
         switch selectedTab {
         case .general: return 680
         case .services: return 580
+        case .providerOrder: return 520
         case .about: return 420
         }
     }
@@ -28,6 +29,12 @@ struct SettingsView: View {
                     Label("Services", systemImage: "globe")
                 }
                 .tag(SettingsTab.services)
+
+            ProviderOrderSettingsView(registry: registry)
+                .tabItem {
+                    Label("Order", systemImage: "list.number")
+                }
+                .tag(SettingsTab.providerOrder)
 
             AboutSettingsView(updaterController: updaterController)
                 .tabItem {

--- a/Sources/Utilities/Constants.swift
+++ b/Sources/Utilities/Constants.swift
@@ -44,6 +44,7 @@ enum AppLanguage: String, CaseIterable, Defaults.Serializable {
 enum SettingsTab: String, Defaults.Serializable {
     case general
     case services
+    case providerOrder
     case about
 }
 
@@ -64,6 +65,9 @@ extension Defaults.Keys {
 
     // Enabled translation providers
     static let enabledProviders = Key<Set<String>>("enabledProviders", default: ["openai"])
+
+    // User-defined display order for providers (ordered list of provider IDs)
+    static let providerOrder = Key<[String]>("providerOrder", default: [])
 
     // Language detection
     static let detectionConfidenceThreshold = Key<Double>("detectionConfidenceThreshold", default: 0.3)


### PR DESCRIPTION
## Summary

- **输入翻译弹窗键盘焦点**：Option+A 打开输入翻译弹窗时，通过 `NSApp.activate(ignoringOtherApps:)` 激活 app，使文本框自动获得键盘焦点，可直接打字输入
- **Provider 显示排序**：新增设置 tab "Order"，支持拖拽调整已启用 provider 的显示顺序，排序持久化到 UserDefaults 并影响翻译结果显示顺序
- **空输入按回车不响应**：输入框为空时按回车不触发翻译、不显示错误，输入框保持可用状态

## Changes

| 文件 | 改动 |
|------|------|
| `SourceInputView.swift` | 空文本 guard，阻止空输入提交 |
| `PopupPanelController.swift` | `showAtScreenCenter()` 中激活 app |
| `Constants.swift` | 新增 `providerOrder` Defaults key + `SettingsTab.providerOrder` |
| `TranslationProviderRegistry.swift` | `enabledSlots` 尊重排序；`removeCustomProvider` 清理排序 |
| `ServiceSettingsView.swift` | 启用/禁用 provider 时同步排序列表 |
| `SettingsView.swift` | 注册 "Order" tab |
| `ProviderOrderSettingsView.swift` | 新建排序设置页，List + onMove 拖拽排序 |
| `Localizable.xcstrings` | 5 条新增 zh-Hans 翻译 |

## Test plan

- [ ] 按 Option+A，弹窗出现后直接打字，验证文本输入框有焦点
- [ ] 打开输入翻译弹窗，不输入任何内容直接按回车，验证无任何反应
- [ ] 启用多个 provider，在设置 → Order tab 中拖拽调整顺序
- [ ] 调整顺序后翻译文本，验证结果页 provider 顺序与设置一致
- [ ] 关闭 app 重启，验证排序已持久化

🤖 Generated with [Claude Code](https://claude.com/claude-code)