### PR TITLE
fix(Popup): 修复 macOS 15 下弹窗上半区原文不显示

### DIFF
--- a/Sources/UI/PopupPanel/ProviderResultCard.swift
+++ b/Sources/UI/PopupPanel/ProviderResultCard.swift
@@ -103,6 +103,7 @@ struct ProviderResultCard: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text(partial)
                     .font(.popup(name: fontName, size: CGFloat(fontSize)))
+                    .foregroundStyle(.primary)
                     .textSelection(.enabled)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
@@ -111,6 +112,7 @@ struct ProviderResultCard: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text(text)
                     .font(.popup(name: fontName, size: CGFloat(fontSize)))
+                    .foregroundStyle(.primary)
                     .textSelection(.enabled)
                     .frame(maxWidth: .infinity, alignment: .leading)
 

--- a/Sources/UI/PopupPanel/SourceInputView.swift
+++ b/Sources/UI/PopupPanel/SourceInputView.swift
@@ -52,23 +52,38 @@ private struct SourceTextEditor: NSViewRepresentable {
         scrollView.hasHorizontalScroller = false
         scrollView.autohidesScrollers = true
         scrollView.drawsBackground = false
+        scrollView.contentView.drawsBackground = false
 
-        let textView = SubmitAwareTextView()
+        let contentSize = scrollView.contentSize
+        let textView = SubmitAwareTextView(frame: NSRect(origin: .zero, size: contentSize))
         textView.isRichText = false
         textView.isAutomaticQuoteSubstitutionEnabled = false
         textView.isAutomaticDashSubstitutionEnabled = false
         textView.isAutomaticTextReplacementEnabled = false
         textView.isContinuousSpellCheckingEnabled = false
+        textView.importsGraphics = false
         textView.allowsUndo = true
         textView.drawsBackground = false
+        textView.backgroundColor = .clear
+        textView.minSize = NSSize(width: 0, height: contentSize.height)
+        textView.maxSize = NSSize(
+            width: CGFloat.greatestFiniteMagnitude,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = false
+        textView.autoresizingMask = [.width]
         textView.delegate = context.coordinator
-        textView.string = text
-        textView.font = resolvedFont
-        textView.textColor = .labelColor
-        textView.insertionPointColor = .labelColor
         textView.textContainerInset = .zero
-        textView.textContainer?.lineFragmentPadding = 0
         textView.onSubmit = onSubmit
+        textView.textContainer?.containerSize = NSSize(
+            width: contentSize.width,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+        textView.textContainer?.widthTracksTextView = true
+        textView.textContainer?.lineFragmentPadding = 0
+        textView.applyDisplayAttributes(font: resolvedFont)
+        textView.setExternalText(text)
 
         scrollView.documentView = textView
         context.coordinator.textView = textView
@@ -84,13 +99,13 @@ private struct SourceTextEditor: NSViewRepresentable {
     func updateNSView(_ nsView: NSScrollView, context: Context) {
         guard let textView = context.coordinator.textView else { return }
 
+        textView.applyDisplayAttributes(font: resolvedFont)
+        textView.updateLayout(for: nsView.contentSize)
+
         if textView.string != text {
-            textView.string = text
+            textView.setExternalText(text)
         }
 
-        textView.font = resolvedFont
-        textView.textColor = .labelColor
-        textView.insertionPointColor = .labelColor
         textView.onSubmit = onSubmit
 
         if !context.coordinator.didFocusInitially {
@@ -112,7 +127,8 @@ private struct SourceTextEditor: NSViewRepresentable {
         }
 
         func textDidChange(_ notification: Notification) {
-            guard let textView = notification.object as? NSTextView else { return }
+            guard let textView = notification.object as? SubmitAwareTextView else { return }
+            textView.refreshDisplay()
             text = textView.string
         }
     }
@@ -120,6 +136,47 @@ private struct SourceTextEditor: NSViewRepresentable {
 
 private final class SubmitAwareTextView: NSTextView {
     var onSubmit: (() -> Void)?
+    private var displayFont: NSFont = .systemFont(ofSize: NSFont.systemFontSize)
+
+    func applyDisplayAttributes(font: NSFont) {
+        displayFont = font
+        self.font = displayFont
+        textColor = .labelColor
+        insertionPointColor = .labelColor
+        typingAttributes = mergedTypingAttributes()
+        selectedTextAttributes = [
+            .foregroundColor: NSColor.selectedTextColor,
+            .backgroundColor: NSColor.selectedTextBackgroundColor,
+        ]
+        applyDisplayAttributesToTextStorage()
+        refreshDisplay()
+    }
+
+    func setExternalText(_ newValue: String) {
+        string = newValue
+        typingAttributes = mergedTypingAttributes()
+        applyDisplayAttributesToTextStorage()
+        setSelectedRange(NSRange(location: (newValue as NSString).length, length: 0))
+        refreshDisplay()
+    }
+
+    func updateLayout(for contentSize: NSSize) {
+        minSize = NSSize(width: 0, height: contentSize.height)
+        if let textContainer {
+            textContainer.containerSize = NSSize(
+                width: contentSize.width,
+                height: CGFloat.greatestFiniteMagnitude
+            )
+            textContainer.widthTracksTextView = true
+        }
+        frame.size.width = contentSize.width
+        refreshDisplay()
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        applyDisplayAttributes(font: displayFont)
+    }
 
     override func keyDown(with event: NSEvent) {
         let isReturnKey = event.keyCode == 36 || event.keyCode == 76
@@ -134,5 +191,38 @@ private final class SubmitAwareTextView: NSTextView {
         }
 
         super.keyDown(with: event)
+    }
+
+    private func mergedTypingAttributes() -> [NSAttributedString.Key: Any] {
+        var attributes = typingAttributes
+        attributes[.font] = displayFont
+        attributes[.foregroundColor] = NSColor.labelColor
+        return attributes
+    }
+
+    private func applyDisplayAttributesToTextStorage() {
+        guard let textStorage else { return }
+        let range = NSRange(location: 0, length: textStorage.length)
+        textStorage.beginEditing()
+        if range.length > 0 {
+            textStorage.addAttributes(
+                [
+                    .font: displayFont,
+                    .foregroundColor: NSColor.labelColor,
+                ],
+                range: range
+            )
+        }
+        textStorage.endEditing()
+    }
+
+    func refreshDisplay() {
+        if let textContainer, let layoutManager {
+            layoutManager.ensureLayout(for: textContainer)
+        }
+        needsDisplay = true
+        setNeedsDisplay(bounds)
+        enclosingScrollView?.contentView.needsDisplay = true
+        enclosingScrollView?.needsDisplay = true
     }
 }


### PR DESCRIPTION
## Summary

修复 macOS 15 下 MoePeek 弹窗上半区原文/输入区空白的问题。

这个问题只影响上半区 `NSTextView`，下半区翻译结果本身是正常的。此次修复主要从 AppKit 文本视图初始化方式、外部文本更新语义，以及内容变更后的布局/重绘三个方面处理。

## Changes

- 按标准 AppKit 方式重建 `NSTextView` + `NSScrollView` 配置
- 将“样式刷新”和“外部文本写入”拆分，避免更新内容时误伤输入状态
- 外部注入文本后将光标移动到文本末尾，不再停留在开头
- 在文本更新、输入变化、外观变化后显式触发布局和重绘
- 保留结果区 `.foregroundStyle(.primary)` 的补强，避免下半区文字受同类问题影响

## Verification

本地验证通过以下场景：

- 手动翻译
- 选中翻译
- 剪贴板翻译
- 截图 OCR

确认结果：

- 上半区原文/输入内容可以正常显示
- 下半区翻译结果仍然正常显示
- 外部写入文本后，光标不再固定在开头

Fixes #34  
Relates to #32
