### PR TITLE
fix(Dock): explicitly set activation policy on launch

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -28,11 +28,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         onboardingController = OnboardingWindowController(permissionManager: permissionManager, registry: registry)
         selectionMonitor = SelectionMonitor()
         triggerIconController = TriggerIconController()
-        // Apply dock visibility — only switch to .regular when needed;
-        // LSUIElement=YES already provides .accessory by default.
-        if Defaults[.showInDock] {
-            NSApp.setActivationPolicy(.regular)
-        }
+        // Apply dock visibility — always set explicitly because macOS may cache
+        // .regular from a previous session, ignoring LSUIElement on relaunch.
+        NSApp.setActivationPolicy(Defaults[.showInDock] ? .regular : .accessory)
 
         setupShortcuts()
         setupSelectionMonitor()


### PR DESCRIPTION
Fixes #47

## Summary
- macOS may cache `.regular` activation policy from a previous session, causing the Dock icon to reappear on relaunch even with `LSUIElement=YES`
- Always explicitly call `setActivationPolicy` on launch instead of only setting `.regular` when `showInDock` is true
- Fixes: toggling "Show Dock icon" off → quit → relaunch still showed Dock icon

## Test plan
- [ ] Turn off "Show Dock icon" in Settings, quit and relaunch → Dock icon should not appear
- [ ] Turn on "Show Dock icon", quit and relaunch → Dock icon should appear
- [ ] Toggle on/off at runtime still works as before