### PR TITLE
feat(TTS): add text-to-speech support with Apple TTS provider

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -224,6 +224,16 @@
         }
       }
     },
+    "Apps in the blocklist will not trigger automatic text selection detection." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "如果 App 在「排除应用」名单中，则不会触发鼠标自动划词。"
+          }
+        }
+      }
+    },
     "Are you sure you want to delete \"%@\"? This will remove all its settings." : {
       "localizations" : {
         "zh-Hans" : {
@@ -245,16 +255,6 @@
         }
       }
     },
-    "Apps in the blocklist will not trigger automatic text selection detection." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "如果 App 在「排除应用」名单中，则不会触发鼠标自动划词。"
-          }
-        }
-      }
-    },
     "Auto Detect" : {
       "localizations" : {
         "zh-Hans" : {
@@ -272,6 +272,39 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自动检测源语言"
+          }
+        }
+      }
+    },
+    "Auto-play provider" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动朗读提供者"
+          }
+        }
+      }
+    },
+    "Auto-play source text" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动朗读原文"
+          }
+        }
+      }
+    },
+    "Auto-play translation result" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动朗读译文"
           }
         }
       }
@@ -560,6 +593,16 @@
         }
       }
     },
+    "Default Speech Rate" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "默认语速"
+          }
+        }
+      }
+    },
     "Default Width: %lld" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -694,6 +737,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "获取可用模型列表"
+          }
+        }
+      }
+    },
+    "First completed" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第一个完成的"
           }
         }
       }
@@ -1393,6 +1446,16 @@
         }
       }
     },
+    "Per-Language Rate" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "按语言设置语速"
+          }
+        }
+      }
+    },
     "Permissions Need Re-Authorization" : {
       "localizations" : {
         "zh-Hans" : {
@@ -1442,6 +1505,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "弹出面板"
+          }
+        }
+      }
+    },
+    "Preferences" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "偏好设置"
           }
         }
       }
@@ -1593,6 +1666,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "用于读取选中的文本"
+          }
+        }
+      }
+    },
+    "Reset to default rate" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重置为默认语速"
           }
         }
       }
@@ -1836,6 +1920,16 @@
         }
       }
     },
+    "Service" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "服务"
+          }
+        }
+      }
+    },
     "Services" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -2026,6 +2120,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "目标语言："
+          }
+        }
+      }
+    },
+    "Test" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "测试"
           }
         }
       }
@@ -2314,6 +2418,9 @@
           }
         }
       }
+    },
+    "x" : {
+
     },
     "Youdao decryption failed. Please try again." : {
       "extractionState" : "stale",

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -8,6 +8,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     // registry must be available before applicationDidFinishLaunching because
     // SwiftUI evaluates MoePeekApp.body (which reads registry) during app init.
     lazy var registry = TranslationProviderRegistry.builtIn()
+    lazy var ttsRegistry = TTSProviderRegistry.builtIn()
+    lazy var ttsCoordinator = TTSCoordinator(registry: ttsRegistry)
     var coordinator: TranslationCoordinator!
     var panelController: PopupPanelController!
     var permissionManager: PermissionManager!
@@ -24,7 +26,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         permissionManager = PermissionManager()
         coordinator = TranslationCoordinator(permissionManager: permissionManager, registry: registry)
-        panelController = PopupPanelController(coordinator: coordinator)
+        panelController = PopupPanelController(coordinator: coordinator, ttsCoordinator: ttsCoordinator)
         onboardingController = OnboardingWindowController(permissionManager: permissionManager, registry: registry)
         selectionMonitor = SelectionMonitor()
         triggerIconController = TriggerIconController()

--- a/Sources/App/MoePeekApp.swift
+++ b/Sources/App/MoePeekApp.swift
@@ -12,7 +12,12 @@ struct MoePeekApp: App {
 
         // Settings window
         Settings {
-            SettingsView(registry: appDelegate.registry, updaterController: appDelegate.updaterController)
+            SettingsView(
+                registry: appDelegate.registry,
+                ttsRegistry: appDelegate.ttsRegistry,
+                ttsCoordinator: appDelegate.ttsCoordinator,
+                updaterController: appDelegate.updaterController
+            )
         }
         .windowResizability(.contentMinSize)
     }

--- a/Sources/Core/TTSCoordinator.swift
+++ b/Sources/Core/TTSCoordinator.swift
@@ -1,0 +1,96 @@
+import Defaults
+import Foundation
+import Observation
+
+@MainActor @Observable
+final class TTSCoordinator {
+    enum PlaybackState: Equatable {
+        case idle
+        case loading
+        case playing(providerID: String)
+        case error(String)
+    }
+
+    private(set) var playbackState: PlaybackState = .idle
+    /// The text currently being spoken, used to scope UI state per-button.
+    private(set) var currentText: String?
+    private var speakTask: Task<Void, Never>?
+    private var activePlaybackProvider: (any TTSProvider)?
+
+    private let registry: TTSProviderRegistry
+
+    init(registry: TTSProviderRegistry) {
+        self.registry = registry
+    }
+
+    func speak(_ text: String, language: String) {
+        stop()
+        currentText = text
+
+        speakTask = Task { [weak self] in
+            guard let self else { return }
+            let provider = registry.activeProvider
+            activePlaybackProvider = provider
+            playbackState = .loading
+
+            do {
+                try await performSpeak(provider, text: text, language: language)
+            } catch {
+                guard !Task.isCancelled else { return }
+
+                // Fallback to Apple TTS if the current provider isn't Apple
+                if provider.id != AppleTTSProvider.providerID,
+                   let apple = registry.provider(withID: AppleTTSProvider.providerID)
+                {
+                    print("[TTS] \(provider.displayName) failed: \(error.localizedDescription), falling back to Apple TTS")
+                    do {
+                        try await performSpeak(apple, text: text, language: language)
+                    } catch {
+                        if !Task.isCancelled {
+                            playbackState = .error(error.localizedDescription)
+                        }
+                    }
+                } else {
+                    playbackState = .error(error.localizedDescription)
+                }
+            }
+
+            self.speakTask = nil
+        }
+    }
+
+    func stop() {
+        speakTask?.cancel()
+        speakTask = nil
+        activePlaybackProvider?.stop()
+        activePlaybackProvider = nil
+        currentText = nil
+        playbackState = .idle
+    }
+
+    var isPlaying: Bool {
+        if case .playing = playbackState { return true }
+        if case .loading = playbackState { return true }
+        return false
+    }
+
+    func isPlaying(_ text: String) -> Bool {
+        isPlaying && currentText == text
+    }
+
+    private func performSpeak(_ provider: any TTSProvider, text: String, language: String) async throws {
+        playbackState = .playing(providerID: provider.id)
+        let rate = effectiveRate(for: language)
+        try await provider.speak(text, language: language, accent: Defaults[.ttsAccent], rate: rate)
+        if !Task.isCancelled {
+            playbackState = .idle
+        }
+    }
+
+    private func effectiveRate(for language: String) -> Float {
+        if let override = Defaults[.ttsLanguageRates][language] {
+            return Float(override)
+        }
+        return Float(Defaults[.ttsSpeechRate])
+    }
+}

--- a/Sources/Services/TTS/AppleTTSProvider.swift
+++ b/Sources/Services/TTS/AppleTTSProvider.swift
@@ -1,0 +1,138 @@
+import AVFoundation
+import SwiftUI
+
+final class AppleTTSProvider: TTSProvider, @unchecked Sendable {
+    static let providerID = "apple"
+
+    let id = providerID
+    let displayName = "Apple TTS"
+    let iconSystemName = "apple.logo"
+    let isAvailable = true
+    @MainActor var isConfigured: Bool { true }
+
+    private let synthesizer = AVSpeechSynthesizer()
+    private lazy var cachedVoices = AVSpeechSynthesisVoice.speechVoices()
+
+    @MainActor func speak(
+        _ text: String,
+        language: String,
+        accent: TTSAccent,
+        rate: Float
+    ) async throws {
+        let voiceLang = resolveVoiceLanguage(language: language, accent: accent)
+        let utterance = AVSpeechUtterance(string: text)
+
+        if let voice = bestVoice(for: voiceLang) {
+            utterance.voice = voice
+        } else if let voice = AVSpeechSynthesisVoice(language: voiceLang) {
+            utterance.voice = voice
+        }
+
+        // Map rate 0.5–2.0 to AVSpeechUtterance rate range.
+        // AVSpeechUtteranceDefaultSpeechRate is 0.5, min is 0.0, max is 1.0.
+        let normalizedRate = AVSpeechUtteranceDefaultSpeechRate * rate
+        utterance.rate = min(max(normalizedRate, AVSpeechUtteranceMinimumSpeechRate), AVSpeechUtteranceMaximumSpeechRate)
+
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            let delegate = SpeechDelegate(continuation: continuation)
+            // Retain delegate until speech finishes
+            objc_setAssociatedObject(self.synthesizer, &AssociatedKeys.delegate, delegate, .OBJC_ASSOCIATION_RETAIN)
+            self.synthesizer.delegate = delegate
+            self.synthesizer.speak(utterance)
+        }
+    }
+
+    @MainActor func stop() {
+        synthesizer.stopSpeaking(at: .immediate)
+    }
+
+    @MainActor func makeSettingsView() -> AnyView {
+        AnyView(
+            Label(
+                String(localized: "System built-in, no configuration needed."),
+                systemImage: "checkmark.circle.fill"
+            )
+            .foregroundStyle(.green)
+        )
+    }
+
+    // MARK: - Voice Selection
+
+    private func resolveVoiceLanguage(language: String, accent: TTSAccent) -> String {
+        if language == "en" {
+            return accent == .british ? "en-GB" : "en-US"
+        }
+        let mapping: [String: String] = [
+            "zh-Hans": "zh-CN",
+            "zh-Hant": "zh-TW",
+        ]
+        return mapping[language] ?? language
+    }
+
+    private func bestVoice(for language: String) -> AVSpeechSynthesisVoice? {
+        let langPrefix = language.lowercased().prefix(2)
+        let voices = cachedVoices
+            .filter { $0.language.lowercased().hasPrefix(String(langPrefix)) }
+            .sorted { voiceQuality($0) > voiceQuality($1) }
+
+        if let exact = voices.first(where: { $0.language.lowercased() == language.lowercased() }) {
+            return exact
+        }
+        return voices.first
+    }
+
+    private func voiceQuality(_ voice: AVSpeechSynthesisVoice) -> Int {
+        switch voice.quality {
+        case .premium: return 3
+        case .enhanced: return 2
+        case .default: return 1
+        @unknown default: return 0
+        }
+    }
+}
+
+// MARK: - Speech Delegate
+
+private enum AssociatedKeys {
+    static var delegate: UInt8 = 0
+}
+
+private final class SpeechDelegate: NSObject, AVSpeechSynthesizerDelegate, Sendable {
+    private let continuation: CheckedContinuation<Void, Never>
+    private let resumed = LockedAtomic(false)
+
+    init(continuation: CheckedContinuation<Void, Never>) {
+        self.continuation = continuation
+    }
+
+    func speechSynthesizer(_: AVSpeechSynthesizer, didFinish _: AVSpeechUtterance) {
+        resumeOnce()
+    }
+
+    func speechSynthesizer(_: AVSpeechSynthesizer, didCancel _: AVSpeechUtterance) {
+        resumeOnce()
+    }
+
+    private func resumeOnce() {
+        if resumed.exchange(true) == false {
+            continuation.resume()
+        }
+    }
+}
+
+private final class LockedAtomic<T: Equatable>: @unchecked Sendable {
+    private var value: T
+    private let lock = NSLock()
+
+    init(_ value: T) {
+        self.value = value
+    }
+
+    func exchange(_ newValue: T) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        let old = value
+        value = newValue
+        return old
+    }
+}

--- a/Sources/Services/TTSProvider.swift
+++ b/Sources/Services/TTSProvider.swift
@@ -1,0 +1,84 @@
+import Defaults
+import Foundation
+import SwiftUI
+
+// MARK: - TTS Accent
+
+enum TTSAccent: String, CaseIterable, Defaults.Serializable {
+    case american
+    case british
+
+    var displayName: String {
+        switch self {
+        case .american: String(localized: "American English")
+        case .british: String(localized: "British English")
+        }
+    }
+
+    var shortLabel: String {
+        switch self {
+        case .american: "US"
+        case .british: "UK"
+        }
+    }
+}
+
+// MARK: - TTS Provider Protocol
+
+/// Plugin protocol for text-to-speech backends. Each provider is self-contained:
+/// owns its playback logic, settings UI, and configuration storage.
+protocol TTSProvider: AnyObject, Sendable {
+    var id: String { get }
+    var displayName: String { get }
+    var iconSystemName: String { get }
+    var isAvailable: Bool { get }
+    @MainActor var isConfigured: Bool { get }
+
+    /// Speak the given text. Provider manages its own playback internally
+    /// (AVSpeechSynthesizer for system TTS, AVPlayer for URL-based services).
+    /// This method returns when playback finishes or is cancelled.
+    @MainActor func speak(
+        _ text: String,
+        language: String,
+        accent: TTSAccent,
+        rate: Float
+    ) async throws
+
+    /// Stop any in-progress playback immediately.
+    @MainActor func stop()
+
+    /// Return a settings view for this provider.
+    @MainActor func makeSettingsView() -> AnyView
+}
+
+// MARK: - TTS Errors
+
+enum TTSError: LocalizedError {
+    case unsupportedLanguage(String)
+    case networkError(String)
+    case playbackFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .unsupportedLanguage(lang):
+            return String(localized: "Language not supported for TTS: \(lang)")
+        case let .networkError(message):
+            return String(localized: "TTS network error: \(message)")
+        case let .playbackFailed(message):
+            return String(localized: "TTS playback failed: \(message)")
+        }
+    }
+}
+
+// MARK: - Environment Key
+
+private struct TTSCoordinatorKey: EnvironmentKey {
+    static let defaultValue: TTSCoordinator? = nil
+}
+
+extension EnvironmentValues {
+    var ttsCoordinator: TTSCoordinator? {
+        get { self[TTSCoordinatorKey.self] }
+        set { self[TTSCoordinatorKey.self] = newValue }
+    }
+}

--- a/Sources/Services/TTSProviderRegistry.swift
+++ b/Sources/Services/TTSProviderRegistry.swift
@@ -1,0 +1,30 @@
+import Defaults
+import Foundation
+import Observation
+
+/// Container for all registered TTS providers. Single-selection model:
+/// only one provider is active at a time, stored in Defaults.
+@MainActor @Observable
+final class TTSProviderRegistry {
+    private(set) var providers: [any TTSProvider]
+
+    init(providers: [any TTSProvider]) {
+        precondition(!providers.isEmpty, "TTSProviderRegistry requires at least one provider")
+        self.providers = providers
+    }
+
+    /// The currently selected TTS provider.
+    var activeProvider: any TTSProvider {
+        provider(withID: Defaults[.ttsProvider]) ?? providers[0]
+    }
+
+    func provider(withID id: String) -> (any TTSProvider)? {
+        providers.first { $0.id == id }
+    }
+
+    static func builtIn() -> TTSProviderRegistry {
+        TTSProviderRegistry(providers: [
+            AppleTTSProvider(),
+        ])
+    }
+}

--- a/Sources/UI/PopupPanel/PopupPanelController.swift
+++ b/Sources/UI/PopupPanel/PopupPanelController.swift
@@ -11,9 +11,11 @@ final class PopupPanelController {
     private var dismissMonitor: PopupDismissMonitor?
 
     private let coordinator: TranslationCoordinator
+    private let ttsCoordinator: TTSCoordinator?
 
-    init(coordinator: TranslationCoordinator) {
+    init(coordinator: TranslationCoordinator, ttsCoordinator: TTSCoordinator? = nil) {
         self.coordinator = coordinator
+        self.ttsCoordinator = ttsCoordinator
     }
 
     func showAtCursor() {
@@ -64,6 +66,7 @@ final class PopupPanelController {
     func dismiss() {
         dismissMonitor?.stop()
         dismissMonitor = nil
+        ttsCoordinator?.stop()
         panel?.contentView = nil
         panel?.close()
         // Recreate panel on next show to ensure a fresh SwiftUI view tree,
@@ -95,6 +98,7 @@ final class PopupPanelController {
                 }
             )
             .environment(\.popupPanel, newPanel)
+            .environment(\.ttsCoordinator, ttsCoordinator)
             let hostingView = NSHostingView(rootView: contentView)
             // Prevent NSHostingView from auto-resizing the window on content changes,
             // which causes an infinite constraint update loop during streaming.

--- a/Sources/UI/PopupPanel/PopupView.swift
+++ b/Sources/UI/PopupPanel/PopupView.swift
@@ -9,6 +9,8 @@ struct PopupView: View {
     @State private var editableText: String = ""
     @State private var isOpeningSettings = false
     @State private var expandedProviders: Set<String> = []
+    @State private var autoPlayedGeneration: Int = -1
+    @Environment(\.ttsCoordinator) private var ttsCoordinator
     @State private var sourceLang: String = Defaults[.sourceLanguage]
     @State private var targetLang: String = Defaults[.targetLanguage]
     @State private var inputHeight: CGFloat = CGFloat(Defaults[.popupInputHeight])
@@ -63,6 +65,13 @@ struct PopupView: View {
         .clipShape(RoundedRectangle(cornerRadius: 12))
         .onChange(of: coordinator.sourceText) { _, newValue in
             editableText = newValue
+            if Defaults[.ttsAutoPlaySource],
+               !newValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+               let tts = ttsCoordinator
+            {
+                let lang = coordinator.detectedLanguage ?? Defaults[.sourceLanguage]
+                tts.speak(newValue, language: lang)
+            }
         }
         .onChange(of: coordinator.targetLanguage) { _, newValue in
             targetLang = newValue
@@ -72,9 +81,20 @@ struct PopupView: View {
             sourceLang = Defaults[.sourceLanguage]
             targetLang = coordinator.targetLanguage
             expandedProviders = Set(coordinator.activeSlots.map(\.id))
+
+            if Defaults[.ttsAutoPlaySource],
+               !coordinator.sourceText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+               let tts = ttsCoordinator
+            {
+                let lang = coordinator.detectedLanguage ?? Defaults[.sourceLanguage]
+                tts.speak(coordinator.sourceText, language: lang)
+            }
         }
         .onChange(of: coordinator.translationGeneration) { _, _ in
             expandedProviders = Set(coordinator.activeSlots.map(\.id))
+        }
+        .onChange(of: coordinator.providerStates) { _, newStates in
+            handleAutoPlay(states: newStates)
         }
     }
 
@@ -95,6 +115,7 @@ struct PopupView: View {
                 // Source input
                 SourceInputView(
                     text: $editableText,
+                    sourceLanguage: coordinator.detectedLanguage ?? sourceLang,
                     onSubmit: {
                         coordinator.translate(editableText)
                     }
@@ -199,6 +220,7 @@ struct PopupView: View {
                                 ProviderResultCard(
                                     provider: provider,
                                     state: state,
+                                    targetLanguage: targetLang,
                                     isExpanded: expandedBinding(for: provider.id),
                                     onRetry: {
                                         coordinator.retryProvider(provider)
@@ -228,6 +250,38 @@ struct PopupView: View {
                 }
             }
         )
+    }
+
+    private func handleAutoPlay(states: [String: TranslationCoordinator.ProviderState]) {
+        guard Defaults[.ttsAutoPlayTarget],
+              let tts = ttsCoordinator,
+              coordinator.translationGeneration != autoPlayedGeneration else { return }
+
+        let preferredProvider = Defaults[.ttsAutoPlayTargetProvider]
+
+        let completedText: String?
+        if preferredProvider == "first" {
+            // Auto-play the first provider (in display order) that has completed
+            completedText = coordinator.activeSlots
+                .lazy
+                .compactMap { provider -> String? in
+                    if case .completed(let text) = states[provider.id] { return text }
+                    return nil
+                }
+                .first
+        } else {
+            // Wait for the specific provider to complete
+            if case .completed(let text) = states[preferredProvider] {
+                completedText = text
+            } else {
+                completedText = nil
+            }
+        }
+
+        if let text = completedText {
+            autoPlayedGeneration = coordinator.translationGeneration
+            tts.speak(text, language: targetLang)
+        }
     }
 
     @MainActor

--- a/Sources/UI/PopupPanel/ProviderResultCard.swift
+++ b/Sources/UI/PopupPanel/ProviderResultCard.swift
@@ -5,10 +5,13 @@ import SwiftUI
 struct ProviderResultCard: View {
     let provider: any TranslationProvider
     let state: TranslationCoordinator.ProviderState
+    let targetLanguage: String
     @Binding var isExpanded: Bool
     var onRetry: (() -> Void)?
     @Default(.popupFontSize) private var fontSize
     @Default(.popupFontName) private var fontName
+    @Default(.ttsAccent) private var ttsAccent
+    @Environment(\.ttsCoordinator) private var ttsCoordinator
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -58,6 +61,10 @@ struct ProviderResultCard: View {
             RoundedRectangle(cornerRadius: 6)
                 .stroke(Color.primary.opacity(0.06), lineWidth: 0.5)
         )
+    }
+
+    private func isSpeaking(_ text: String) -> Bool {
+        ttsCoordinator?.isPlaying(text) ?? false
     }
 
     // MARK: - Status Indicator
@@ -118,6 +125,28 @@ struct ProviderResultCard: View {
 
                 HStack {
                     Spacer()
+
+                    if let ttsCoordinator {
+                        Button {
+                            if isSpeaking(text) {
+                                ttsCoordinator.stop()
+                            } else {
+                                ttsCoordinator.speak(text, language: targetLanguage)
+                            }
+                        } label: {
+                            HStack(spacing: 2) {
+                                Image(systemName: isSpeaking(text) ? "speaker.wave.3.fill" : "speaker.wave.2")
+                                if targetLanguage.hasPrefix("en") {
+                                    Text(ttsAccent.shortLabel)
+                                }
+                            }
+                            .font(.popup(name: fontName, size: CGFloat(fontSize - 2)))
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.mini)
+                        .help("Speak")
+                    }
+
                     Button {
                         NSPasteboard.general.clearContents()
                         NSPasteboard.general.setString(text, forType: .string)

--- a/Sources/UI/PopupPanel/SourceInputView.swift
+++ b/Sources/UI/PopupPanel/SourceInputView.swift
@@ -5,9 +5,12 @@ import SwiftUI
 /// Editable source text input with Enter to translate, Shift+Enter for newline.
 struct SourceInputView: View {
     @Binding var text: String
+    let sourceLanguage: String
     let onSubmit: () -> Void
     @Default(.popupFontSize) private var fontSize
     @Default(.popupFontName) private var fontName
+    @Default(.ttsAccent) private var ttsAccent
+    @Environment(\.ttsCoordinator) private var ttsCoordinator
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -21,6 +24,31 @@ struct SourceInputView: View {
                 .background { InteractiveMarker() }
 
             HStack(spacing: 4) {
+                if let ttsCoordinator {
+                    let speaking = ttsCoordinator.isPlaying(text)
+                    Button {
+                        if speaking {
+                            ttsCoordinator.stop()
+                        } else {
+                            ttsCoordinator.speak(text, language: sourceLanguage)
+                        }
+                    } label: {
+                        Image(systemName: speaking ? "speaker.wave.3.fill" : "speaker.wave.2")
+                            .font(.popup(name: fontName, size: CGFloat(fontSize - 2)))
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+                    .disabled(text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    .help("Speak source text")
+                    .background { InteractiveMarker() }
+
+                    if sourceLanguage.hasPrefix("en") {
+                        Text(ttsAccent.shortLabel)
+                            .font(.popup(name: fontName, size: CGFloat(fontSize - 4)))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
                 Spacer()
 
                 Text("↵ Translate · ⇧↵ Newline")

--- a/Sources/UI/Settings/SettingsView.swift
+++ b/Sources/UI/Settings/SettingsView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 
 struct SettingsView: View {
     let registry: TranslationProviderRegistry
+    let ttsRegistry: TTSProviderRegistry
+    let ttsCoordinator: TTSCoordinator
     let updaterController: UpdaterController?
 
     @Default(.selectedSettingsTab) private var selectedTab
@@ -13,6 +15,7 @@ struct SettingsView: View {
         case .excludedApps: return 480
         case .services: return 580
         case .providerOrder: return 520
+        case .audio: return 520
         case .about: return 420
         }
     }
@@ -42,6 +45,12 @@ struct SettingsView: View {
                     Label("Order", systemImage: "list.number")
                 }
                 .tag(SettingsTab.providerOrder)
+
+            TTSSettingsView(registry: ttsRegistry, translationRegistry: registry, coordinator: ttsCoordinator)
+                .tabItem {
+                    Label("Audio", systemImage: "speaker.wave.2")
+                }
+                .tag(SettingsTab.audio)
 
             AboutSettingsView(updaterController: updaterController)
                 .tabItem {

--- a/Sources/UI/Settings/TTSSettingsView.swift
+++ b/Sources/UI/Settings/TTSSettingsView.swift
@@ -1,0 +1,179 @@
+import Defaults
+import SwiftUI
+
+/// Settings view for TTS configuration: service selection, preferences, and testing.
+struct TTSSettingsView: View {
+    let registry: TTSProviderRegistry
+    let translationRegistry: TranslationProviderRegistry
+    let coordinator: TTSCoordinator
+
+    @Default(.ttsProvider) private var selectedProviderID
+    @Default(.ttsAccent) private var accent
+    @Default(.ttsSpeechRate) private var speechRate
+    @Default(.ttsAutoPlaySource) private var autoPlaySource
+    @Default(.ttsAutoPlayTarget) private var autoPlayTarget
+    @Default(.ttsAutoPlayTargetProvider) private var autoPlayTargetProvider
+    @Default(.ttsLanguageRates) private var languageRates
+
+    @State private var isLanguageRatesExpanded = false
+    @State private var testText = "Hello, 你好世界"
+    @State private var testLanguage = "en"
+
+    var body: some View {
+        Form {
+            // MARK: - Service Selection
+
+            Section {
+                Picker("TTS Service", selection: $selectedProviderID) {
+                    ForEach(registry.providers, id: \.id) { provider in
+                        HStack(spacing: 6) {
+                            Image(systemName: provider.iconSystemName)
+                                .frame(width: 16)
+                            Text(provider.displayName)
+                        }
+                        .tag(provider.id)
+                    }
+                }
+
+                registry.activeProvider.makeSettingsView()
+            } header: {
+                Text("Service")
+            }
+
+            // MARK: - Preferences
+
+            Section {
+                Picker("English Accent", selection: $accent) {
+                    ForEach(TTSAccent.allCases, id: \.self) { accent in
+                        Text(accent.displayName).tag(accent)
+                    }
+                }
+
+                HStack {
+                    Text("Default Speech Rate")
+                    Slider(value: $speechRate, in: 0.1 ... 2.0, step: 0.05) {
+                        Text("Default Speech Rate")
+                    }
+                    .labelsHidden()
+                    HStack(spacing: 1) {
+                        TextField("", value: $speechRate, format: .number.precision(.fractionLength(0...2)))
+                            .monospacedDigit()
+                            .frame(width: 48)
+                            .multilineTextAlignment(.trailing)
+                        Text("x")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Toggle("Auto-play source text", isOn: $autoPlaySource)
+                    .onChange(of: autoPlaySource) { _, on in
+                        if on { autoPlayTarget = false }
+                    }
+                Toggle("Auto-play translation result", isOn: $autoPlayTarget)
+                    .onChange(of: autoPlayTarget) { _, on in
+                        if on { autoPlaySource = false }
+                    }
+                if autoPlayTarget {
+                    Picker("Auto-play provider", selection: $autoPlayTargetProvider) {
+                        Text("First completed").tag("first")
+                        ForEach(translationRegistry.providers, id: \.id) { provider in
+                            Text(provider.displayName).tag(provider.id)
+                        }
+                    }
+                }
+
+                DisclosureGroup(isExpanded: $isLanguageRatesExpanded) {
+                    ForEach(SupportedLanguages.all, id: \.code) { lang in
+                        let hasOverride = languageRates[lang.code] != nil
+                        HStack {
+                            Text(lang.name)
+                                .frame(width: 80, alignment: .leading)
+                            Slider(
+                                value: languageRateBinding(for: lang.code),
+                                in: 0.1 ... 2.0,
+                                step: 0.05
+                            )
+                            HStack(spacing: 1) {
+                                TextField("", value: languageRateBinding(for: lang.code), format: .number.precision(.fractionLength(0...2)))
+                                    .monospacedDigit()
+                                    .frame(width: 48)
+                                    .multilineTextAlignment(.trailing)
+                                Text("x")
+                                    .foregroundStyle(.secondary)
+                            }
+                            if hasOverride {
+                                Button {
+                                    languageRates.removeValue(forKey: lang.code)
+                                } label: {
+                                    Image(systemName: "xmark.circle.fill")
+                                        .foregroundStyle(.secondary)
+                                }
+                                .buttonStyle(.plain)
+                                .help("Reset to default rate")
+                            }
+                        }
+                    }
+                } label: {
+                    Text("Per-Language Rate")
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .contentShape(Rectangle())
+                        .onTapGesture { isLanguageRatesExpanded.toggle() }
+                }
+            } header: {
+                Text("Preferences")
+            }
+
+            // MARK: - Test
+
+            Section {
+                TextField("Test text", text: $testText, axis: .vertical)
+                    .lineLimit(1 ... 3)
+
+                Picker("Language", selection: $testLanguage) {
+                    ForEach(SupportedLanguages.all, id: \.code) { lang in
+                        Text(lang.name).tag(lang.code)
+                    }
+                }
+
+                HStack(spacing: 12) {
+                    if coordinator.isPlaying {
+                        Button {
+                            coordinator.stop()
+                        } label: {
+                            Label("Stop", systemImage: "stop.fill")
+                        }
+                        .controlSize(.regular)
+
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        Button {
+                            coordinator.speak(testText, language: testLanguage)
+                        } label: {
+                            Label("Play Test", systemImage: "play.fill")
+                        }
+                        .controlSize(.regular)
+                        .disabled(testText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    }
+
+                    if case let .error(message) = coordinator.playbackState {
+                        Text(message)
+                            .font(.callout)
+                            .foregroundStyle(.red)
+                            .lineLimit(2)
+                    }
+                }
+            } header: {
+                Text("Test")
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    private func languageRateBinding(for code: String) -> Binding<Double> {
+        Binding(
+            get: { languageRates[code] ?? speechRate },
+            set: { languageRates[code] = $0 }
+        )
+    }
+}

--- a/Sources/Utilities/Constants.swift
+++ b/Sources/Utilities/Constants.swift
@@ -54,6 +54,7 @@ enum SettingsTab: String, Defaults.Serializable {
     case excludedApps
     case services
     case providerOrder
+    case audio
     case about
 }
 
@@ -110,4 +111,14 @@ extension Defaults.Keys {
 
     // App language override
     static let appLanguage = Key<AppLanguage>("appLanguage", default: .system)
+
+    // TTS (Text-to-Speech)
+    static let ttsProvider = Key<String>("tts_provider", default: "apple")
+    static let ttsAccent = Key<TTSAccent>("tts_accent", default: .american)
+    static let ttsSpeechRate = Key<Double>("tts_speechRate", default: 1.0)
+    static let ttsAutoPlaySource = Key<Bool>("tts_autoPlaySource", default: false)
+    static let ttsAutoPlayTarget = Key<Bool>("tts_autoPlayTarget", default: false)
+    // "first" = first provider to complete; otherwise a specific provider ID
+    static let ttsAutoPlayTargetProvider = Key<String>("tts_autoPlayTargetProvider", default: "first")
+    static let ttsLanguageRates = Key<[String: Double]>("tts_languageRates", default: [:])
 }


### PR DESCRIPTION
## Summary
- Add TTS infrastructure with provider protocol (`TTSProvider`), registry (`TTSProviderRegistry`), and coordinator (`TTSCoordinator`) following the existing translation provider pattern
- Implement Apple TTS provider using `AVSpeechSynthesizer` with configurable voice, rate, and pitch settings
- Integrate speak buttons into popup panel (source text & translation results) and add dedicated TTS settings view with voice selection and auto-play options

Completed #51 

<img width="2130" height="1158" alt="image" src="https://github.com/user-attachments/assets/cf9b4ff4-3e29-4469-924a-6527a4a43cc1" />