### PR TITLE
feat(Popup): improve translation popup shortcuts

### DIFF
--- a/Sources/Core/TranslationCoordinator.swift
+++ b/Sources/Core/TranslationCoordinator.swift
@@ -34,10 +34,13 @@ final class TranslationCoordinator {
     /// Monotonically increasing counter; increments each time `translate()` is called.
     /// Used by PopupView to reset `expandedProviders` for subsequent translations.
     private(set) var translationGeneration: Int = 0
+    private(set) var copiedProviderID: String?
+    private(set) var copyFeedbackGeneration: Int = 0
 
     let registry: TranslationProviderRegistry
     private let permissionManager: PermissionManager
     private var activeTasks: [String: Task<Void, Never>] = [:]
+    private var copyFeedbackTask: Task<Void, Never>?
 
     init(permissionManager: PermissionManager, registry: TranslationProviderRegistry) {
         self.permissionManager = permissionManager
@@ -98,6 +101,7 @@ final class TranslationCoordinator {
     /// Reset state and enter input mode (empty source input for manual typing).
     func prepareInputMode() {
         cancelAll()
+        clearCopyFeedback()
         globalError = nil
         sourceText = ""
         detectedLanguage = nil
@@ -120,6 +124,7 @@ final class TranslationCoordinator {
         }
 
         cancelAll()
+        clearCopyFeedback()
         globalError = nil
 
         sourceText = trimmed
@@ -182,8 +187,27 @@ final class TranslationCoordinator {
         activeTasks[provider.id] = task
     }
 
+    @discardableResult
+    func copyResult(atDisplayIndex index: Int) -> Bool {
+        guard activeSlots.indices.contains(index) else { return false }
+        return copyResult(forProviderID: activeSlots[index].id)
+    }
+
+    @discardableResult
+    func copyResult(forProviderID providerID: String) -> Bool {
+        guard let resultText = providerStates[providerID]?.copyableText,
+              !resultText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else { return false }
+
+        NSPasteboard.general.clearContents()
+        guard NSPasteboard.general.setString(resultText, forType: .string) else { return false }
+        showCopyFeedback(forProviderID: providerID)
+        return true
+    }
+
     func dismiss() {
         cancelAll()
+        clearCopyFeedback()
         phase = .idle
         sourceText = ""
         detectedLanguage = nil
@@ -260,6 +284,26 @@ final class TranslationCoordinator {
         activeTasks.removeAll()
     }
 
+    private func showCopyFeedback(forProviderID providerID: String) {
+        copyFeedbackTask?.cancel()
+        copiedProviderID = providerID
+        copyFeedbackGeneration += 1
+
+        copyFeedbackTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(900))
+            guard !Task.isCancelled else { return }
+            guard self?.copiedProviderID == providerID else { return }
+            self?.copiedProviderID = nil
+            self?.copyFeedbackTask = nil
+        }
+    }
+
+    private func clearCopyFeedback() {
+        copyFeedbackTask?.cancel()
+        copyFeedbackTask = nil
+        copiedProviderID = nil
+    }
+
     /// Build language hints (BCP 47 codes) based on user's target/source language preferences.
     /// Likely source languages are inferred from the target language for common translation pairs.
     private func buildLanguageHints() -> [String: Double]? {
@@ -327,5 +371,18 @@ final class TranslationCoordinator {
         }
 
         return preferred
+    }
+}
+
+private extension TranslationCoordinator.ProviderState {
+    var copyableText: String? {
+        switch self {
+        case let .streaming(partial):
+            partial
+        case let .completed(text):
+            text
+        case .waiting, .translating, .error:
+            nil
+        }
     }
 }

--- a/Sources/UI/PopupPanel/PopupPanel.swift
+++ b/Sources/UI/PopupPanel/PopupPanel.swift
@@ -15,8 +15,14 @@ extension EnvironmentValues {
     }
 }
 
+enum PopupPanelViewIdentifier {
+    static let sourceInputTextView = "SourceInputTextView"
+}
+
 /// A floating, non-activating panel for showing translation results near the cursor.
 final class PopupPanel: NSPanel {
+    var onCopyResultShortcut: ((Int) -> Bool)?
+
     init(contentRect: NSRect) {
         super.init(
             contentRect: contentRect,
@@ -45,11 +51,26 @@ final class PopupPanel: NSPanel {
     // Allow becoming key window so users can select/copy text within the panel.
     override var canBecomeKey: Bool { true }
 
+    func focusSourceInput(retries: Int = 4) {
+        if focusSourceInputNow() { return }
+        guard retries > 0 else { return }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.03) { [weak self] in
+            self?.focusSourceInput(retries: retries - 1)
+        }
+    }
+
     // MARK: - Selective Window Dragging
 
     /// Intercepts left-mouse-down on non-interactive areas to start a window drag,
     /// while letting interactive controls (text views, buttons, gesture views) handle events normally.
     override func sendEvent(_ event: NSEvent) {
+        if event.type == .keyDown,
+           let resultIndex = copyResultShortcutIndex(for: event),
+           onCopyResultShortcut?(resultIndex) == true {
+            return
+        }
+
         if event.type == .leftMouseDown {
             if shouldStartWindowDrag(for: event) {
                 performDrag(with: event)
@@ -59,6 +80,29 @@ final class PopupPanel: NSPanel {
             if !isKeyWindow { makeKey() }
         }
         super.sendEvent(event)
+    }
+
+    private func copyResultShortcutIndex(for event: NSEvent) -> Int? {
+        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        let disallowedFlags: NSEvent.ModifierFlags = [.shift, .option, .control]
+        guard flags.contains(.command),
+              flags.intersection(disallowedFlags).isEmpty,
+              let characters = event.charactersIgnoringModifiers,
+              characters.count == 1,
+              let number = Int(characters),
+              (1...9).contains(number)
+        else { return nil }
+
+        return number - 1
+    }
+
+    private func focusSourceInputNow() -> Bool {
+        guard let contentView,
+              let textView = findSourceInputTextView(in: contentView)
+        else { return false }
+
+        makeKey()
+        return makeFirstResponder(textView)
     }
 
     private func shouldStartWindowDrag(for event: NSEvent) -> Bool {
@@ -88,5 +132,20 @@ final class PopupPanel: NSPanel {
             if hasInteractiveMarker(in: subview, containing: point) { return true }
         }
         return false
+    }
+
+    private func findSourceInputTextView(in view: NSView) -> NSTextView? {
+        if view.identifier?.rawValue == PopupPanelViewIdentifier.sourceInputTextView,
+           let textView = view as? NSTextView {
+            return textView
+        }
+
+        for subview in view.subviews {
+            if let textView = findSourceInputTextView(in: subview) {
+                return textView
+            }
+        }
+
+        return nil
     }
 }

--- a/Sources/UI/PopupPanel/PopupPanelController.swift
+++ b/Sources/UI/PopupPanel/PopupPanelController.swift
@@ -9,6 +9,7 @@ final class PopupPanelController {
 
     private var panel: PopupPanel?
     private var dismissMonitor: PopupDismissMonitor?
+    private var copyShortcutDismissTask: Task<Void, Never>?
 
     private let coordinator: TranslationCoordinator
 
@@ -16,7 +17,7 @@ final class PopupPanelController {
         self.coordinator = coordinator
     }
 
-    func showAtCursor() {
+    func showAtCursor(focusInput: Bool = true) {
         let initialSize = setupPanel()
         guard let panel else { return }
 
@@ -31,8 +32,14 @@ final class PopupPanelController {
             screen: screen
         )
         panel.setFrame(frame, display: true)
-        // Non-activating: don't steal focus from the user's active app.
-        panel.orderFront(nil)
+        if focusInput {
+            NSApp.activate(ignoringOtherApps: true)
+            panel.makeKeyAndOrderFront(nil)
+            panel.focusSourceInput()
+        } else {
+            // Non-activating: don't steal focus from the user's active app.
+            panel.orderFront(nil)
+        }
 
         startDismissMonitor()
     }
@@ -57,11 +64,14 @@ final class PopupPanelController {
         // because macOS keeps delivering them to the previously active app.
         NSApp.activate(ignoringOtherApps: true)
         panel.makeKeyAndOrderFront(nil)
+        panel.focusSourceInput()
 
         startDismissMonitor()
     }
 
     func dismiss() {
+        copyShortcutDismissTask?.cancel()
+        copyShortcutDismissTask = nil
         dismissMonitor?.stop()
         dismissMonitor = nil
         panel?.contentView = nil
@@ -88,8 +98,14 @@ final class PopupPanelController {
 
         if panel == nil {
             let newPanel = PopupPanel(contentRect: NSRect(origin: .zero, size: initialSize))
+            newPanel.onCopyResultShortcut = { [weak self] index in
+                self?.copyResultFromShortcut(atDisplayIndex: index) ?? false
+            }
             let contentView = PopupView(
                 coordinator: coordinator,
+                onDismiss: { [weak self] in
+                    self?.dismiss()
+                },
                 onOpenSettings: { [weak self] in
                     self?.dismiss()
                 }
@@ -104,6 +120,18 @@ final class PopupPanelController {
         }
 
         return initialSize
+    }
+
+    private func copyResultFromShortcut(atDisplayIndex index: Int) -> Bool {
+        guard coordinator.copyResult(atDisplayIndex: index) else { return false }
+
+        copyShortcutDismissTask?.cancel()
+        copyShortcutDismissTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(280))
+            guard !Task.isCancelled else { return }
+            self?.dismiss()
+        }
+        return true
     }
 
     private func startDismissMonitor() {

--- a/Sources/UI/PopupPanel/PopupView.swift
+++ b/Sources/UI/PopupPanel/PopupView.swift
@@ -1,9 +1,11 @@
+import AppKit
 import Defaults
 import SwiftUI
 
 /// The SwiftUI content displayed inside the popup translation panel.
 struct PopupView: View {
     let coordinator: TranslationCoordinator
+    var onDismiss: (() -> Void)?
     var onOpenSettings: (() -> Void)?
     @Environment(\.openSettings) private var openSettings
     @State private var editableText: String = ""
@@ -14,13 +16,21 @@ struct PopupView: View {
     @State private var inputHeight: CGFloat = CGFloat(Defaults[.popupInputHeight])
     @State private var containerHeight: CGFloat = CGFloat(Defaults[.popupDefaultHeight])
     @Default(.popupFontSize) private var fontSize
+    @Default(.popupFontName) private var fontName
 
     private let inputMinHeight: CGFloat = 36
     private let contentHorizontalPadding: CGFloat = 14
 
+    private var inputSixLineHeight: CGFloat {
+        let editorLineHeight = NSFont.popup(name: fontName, size: CGFloat(fontSize)).lineHeight
+        let hintLineHeight = NSFont.popup(name: fontName, size: max(CGFloat(fontSize - 4), 8)).lineHeight
+        return ceil(editorLineHeight * 6 + hintLineHeight + 8)
+    }
+
     private var maxInputHeight: CGFloat {
-        // Reserve 120pt for language bar + results; floor ensures drag range above inputMinHeight
-        max(containerHeight - 120, inputMinHeight + 24)
+        // Reserve 120pt for language bar + results, while capping the editor at six visible lines.
+        let availableHeight = max(containerHeight - 120, inputMinHeight)
+        return max(inputMinHeight, min(inputSixLineHeight, availableHeight))
     }
 
     var body: some View {
@@ -52,9 +62,7 @@ struct PopupView: View {
             }
         )
         .onChange(of: containerHeight) { _, _ in
-            let clamped = min(inputHeight, maxInputHeight)
-            guard clamped != inputHeight else { return }
-            inputHeight = clamped
+            clampInputHeightToAllowedRange()
         }
         .overlay(alignment: .bottomTrailing) {
             ResizeGripView()
@@ -72,9 +80,14 @@ struct PopupView: View {
             sourceLang = Defaults[.sourceLanguage]
             targetLang = coordinator.targetLanguage
             expandedProviders = Set(coordinator.activeSlots.map(\.id))
+            clampInputHeightToAllowedRange()
         }
         .onChange(of: coordinator.translationGeneration) { _, _ in
             expandedProviders = Set(coordinator.activeSlots.map(\.id))
+        }
+        .onChange(of: coordinator.copiedProviderID) { _, providerID in
+            guard let providerID else { return }
+            expandedProviders.insert(providerID)
         }
     }
 
@@ -97,6 +110,12 @@ struct PopupView: View {
                     text: $editableText,
                     onSubmit: {
                         coordinator.translate(editableText)
+                    },
+                    onCopyAndClose: {
+                        copySourceAndClose()
+                    },
+                    onContentHeightChange: { preferredHeight in
+                        expandInputHeightIfNeeded(for: preferredHeight)
                     }
                 )
                 .frame(height: inputHeight)
@@ -200,6 +219,11 @@ struct PopupView: View {
                                     provider: provider,
                                     state: state,
                                     isExpanded: expandedBinding(for: provider.id),
+                                    isCopyFeedbackActive: coordinator.copiedProviderID == provider.id,
+                                    copyFeedbackGeneration: coordinator.copyFeedbackGeneration,
+                                    onCopy: {
+                                        coordinator.copyResult(forProviderID: provider.id)
+                                    },
                                     onRetry: {
                                         coordinator.retryProvider(provider)
                                     }
@@ -228,6 +252,27 @@ struct PopupView: View {
                 }
             }
         )
+    }
+
+    private func clampInputHeightToAllowedRange() {
+        let clamped = min(max(inputHeight, inputMinHeight), maxInputHeight)
+        guard clamped != inputHeight else { return }
+        inputHeight = clamped
+    }
+
+    private func expandInputHeightIfNeeded(for preferredHeight: CGFloat) {
+        clampInputHeightToAllowedRange()
+        let targetHeight = min(max(preferredHeight, inputMinHeight), maxInputHeight)
+        guard targetHeight > inputHeight else { return }
+        inputHeight = targetHeight
+    }
+
+    private func copySourceAndClose() {
+        let source = editableText
+        guard !source.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        NSPasteboard.general.clearContents()
+        guard NSPasteboard.general.setString(source, forType: .string) else { return }
+        onDismiss?()
     }
 
     @MainActor

--- a/Sources/UI/PopupPanel/ProviderResultCard.swift
+++ b/Sources/UI/PopupPanel/ProviderResultCard.swift
@@ -6,7 +6,11 @@ struct ProviderResultCard: View {
     let provider: any TranslationProvider
     let state: TranslationCoordinator.ProviderState
     @Binding var isExpanded: Bool
+    let isCopyFeedbackActive: Bool
+    let copyFeedbackGeneration: Int
+    var onCopy: (() -> Void)?
     var onRetry: (() -> Void)?
+    @State private var isCopyPulsing = false
     @Default(.popupFontSize) private var fontSize
     @Default(.popupFontName) private var fontName
 
@@ -58,6 +62,18 @@ struct ProviderResultCard: View {
             RoundedRectangle(cornerRadius: 6)
                 .stroke(Color.primary.opacity(0.06), lineWidth: 0.5)
         )
+        .onChange(of: copyFeedbackGeneration) { _, _ in
+            guard isCopyFeedbackActive else { return }
+            withAnimation(.spring(response: 0.18, dampingFraction: 0.55)) {
+                isCopyPulsing = true
+            }
+            Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(180))
+                withAnimation(.spring(response: 0.22, dampingFraction: 0.8)) {
+                    isCopyPulsing = false
+                }
+            }
+        }
     }
 
     // MARK: - Status Indicator
@@ -100,36 +116,9 @@ struct ProviderResultCard: View {
                 .font(.popup(name: fontName, size: CGFloat(fontSize)))
                 .foregroundStyle(.secondary)
         case let .streaming(partial):
-            VStack(alignment: .leading, spacing: 4) {
-                Text(partial)
-                    .font(.popup(name: fontName, size: CGFloat(fontSize)))
-                    .foregroundStyle(.primary)
-                    .textSelection(.enabled)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-            }
-            .background { InteractiveMarker() }
+            resultContent(partial)
         case let .completed(text):
-            VStack(alignment: .leading, spacing: 4) {
-                Text(text)
-                    .font(.popup(name: fontName, size: CGFloat(fontSize)))
-                    .foregroundStyle(.primary)
-                    .textSelection(.enabled)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                HStack {
-                    Spacer()
-                    Button {
-                        NSPasteboard.general.clearContents()
-                        NSPasteboard.general.setString(text, forType: .string)
-                    } label: {
-                        Label("Copy", systemImage: "doc.on.doc")
-                            .font(.popup(name: fontName, size: CGFloat(fontSize - 2)))
-                    }
-                    .buttonStyle(.bordered)
-                    .controlSize(.mini)
-                }
-            }
-            .background { InteractiveMarker() }
+            resultContent(text)
         case let .error(message):
             VStack(alignment: .leading, spacing: 4) {
                 Label(message, systemImage: "exclamationmark.triangle")
@@ -150,5 +139,34 @@ struct ProviderResultCard: View {
             }
             .background { InteractiveMarker() }
         }
+    }
+
+    private func resultContent(_ text: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(text)
+                .font(.popup(name: fontName, size: CGFloat(fontSize)))
+                .foregroundStyle(.primary)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            if let onCopy {
+                HStack {
+                    Spacer()
+                    Button(action: onCopy) {
+                        Label(
+                            isCopyFeedbackActive ? "Copied" : "Copy",
+                            systemImage: isCopyFeedbackActive ? "checkmark" : "doc.on.doc"
+                        )
+                        .font(.popup(name: fontName, size: CGFloat(fontSize - 2)))
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.mini)
+                    .tint(isCopyFeedbackActive ? .green : nil)
+                    .scaleEffect(isCopyPulsing ? 1.08 : 1)
+                    .animation(.easeInOut(duration: 0.12), value: isCopyFeedbackActive)
+                }
+            }
+        }
+        .background { InteractiveMarker() }
     }
 }

--- a/Sources/UI/PopupPanel/SourceInputView.swift
+++ b/Sources/UI/PopupPanel/SourceInputView.swift
@@ -6,6 +6,8 @@ import SwiftUI
 struct SourceInputView: View {
     @Binding var text: String
     let onSubmit: () -> Void
+    let onCopyAndClose: () -> Void
+    var onContentHeightChange: ((CGFloat) -> Void)?
     @Default(.popupFontSize) private var fontSize
     @Default(.popupFontName) private var fontName
 
@@ -15,7 +17,11 @@ struct SourceInputView: View {
                 text: $text,
                 fontSize: CGFloat(fontSize),
                 fontName: fontName,
-                onSubmit: onSubmit
+                onSubmit: onSubmit,
+                onCopyAndClose: onCopyAndClose,
+                onContentHeightChange: { editorHeight in
+                    onContentHeightChange?(sourceInputHeight(forEditorHeight: editorHeight))
+                }
             )
                 .frame(maxHeight: .infinity)
                 .background { InteractiveMarker() }
@@ -23,11 +29,17 @@ struct SourceInputView: View {
             HStack(spacing: 4) {
                 Spacer()
 
-                Text("↵ Translate · ⇧↵ Newline")
+                Text("↵ Translate · ⌘↵ Copy & Close · ⇧↵ Newline")
                     .font(.popup(name: fontName, size: CGFloat(fontSize - 4)))
                     .foregroundStyle(.quaternary)
             }
         }
+    }
+
+    private func sourceInputHeight(forEditorHeight editorHeight: CGFloat) -> CGFloat {
+        let hintSize = max(CGFloat(fontSize - 4), 8)
+        let hintHeight = NSFont.popup(name: fontName, size: hintSize).lineHeight
+        return ceil(editorHeight + hintHeight + 8)
     }
 }
 
@@ -36,6 +48,8 @@ private struct SourceTextEditor: NSViewRepresentable {
     let fontSize: CGFloat
     let fontName: String
     let onSubmit: () -> Void
+    let onCopyAndClose: () -> Void
+    let onContentHeightChange: (CGFloat) -> Void
 
     private var resolvedFont: NSFont {
         .popup(name: fontName, size: fontSize)
@@ -46,6 +60,7 @@ private struct SourceTextEditor: NSViewRepresentable {
     }
 
     func makeNSView(context: Context) -> NSScrollView {
+        let coordinator = context.coordinator
         let scrollView = NSScrollView()
         scrollView.borderType = .noBorder
         scrollView.hasVerticalScroller = true
@@ -56,6 +71,7 @@ private struct SourceTextEditor: NSViewRepresentable {
 
         let contentSize = scrollView.contentSize
         let textView = SubmitAwareTextView(frame: NSRect(origin: .zero, size: contentSize))
+        textView.identifier = NSUserInterfaceItemIdentifier(PopupPanelViewIdentifier.sourceInputTextView)
         textView.isRichText = false
         textView.isAutomaticQuoteSubstitutionEnabled = false
         textView.isAutomaticDashSubstitutionEnabled = false
@@ -73,9 +89,10 @@ private struct SourceTextEditor: NSViewRepresentable {
         textView.isVerticallyResizable = true
         textView.isHorizontallyResizable = false
         textView.autoresizingMask = [.width]
-        textView.delegate = context.coordinator
+        textView.delegate = coordinator
         textView.textContainerInset = .zero
         textView.onSubmit = onSubmit
+        textView.onCopyAndClose = onCopyAndClose
         textView.textContainer?.containerSize = NSSize(
             width: contentSize.width,
             height: CGFloat.greatestFiniteMagnitude
@@ -86,11 +103,12 @@ private struct SourceTextEditor: NSViewRepresentable {
         textView.setExternalText(text)
 
         scrollView.documentView = textView
-        context.coordinator.textView = textView
+        coordinator.textView = textView
+        coordinator.onContentHeightChange = onContentHeightChange
 
-        DispatchQueue.main.async {
-            guard let window = textView.window else { return }
-            window.makeFirstResponder(textView)
+        Task { @MainActor in
+            coordinator.reportContentHeight()
+            coordinator.focusTextViewIfPossible()
         }
 
         return scrollView
@@ -99,6 +117,8 @@ private struct SourceTextEditor: NSViewRepresentable {
     func updateNSView(_ nsView: NSScrollView, context: Context) {
         guard let textView = context.coordinator.textView else { return }
 
+        let coordinator = context.coordinator
+        coordinator.onContentHeightChange = onContentHeightChange
         textView.applyDisplayAttributes(font: resolvedFont)
         textView.updateLayout(for: nsView.contentSize)
 
@@ -107,20 +127,24 @@ private struct SourceTextEditor: NSViewRepresentable {
         }
 
         textView.onSubmit = onSubmit
+        textView.onCopyAndClose = onCopyAndClose
 
-        if !context.coordinator.didFocusInitially {
-            context.coordinator.didFocusInitially = true
-            DispatchQueue.main.async {
-                guard let window = textView.window else { return }
-                window.makeFirstResponder(textView)
+        if !coordinator.didFocusInitially {
+            Task { @MainActor in
+                coordinator.focusTextViewIfPossible()
             }
         }
+
+        coordinator.reportContentHeight()
     }
 
+    @MainActor
     final class Coordinator: NSObject, NSTextViewDelegate {
         @Binding var text: String
         weak var textView: SubmitAwareTextView?
+        var onContentHeightChange: ((CGFloat) -> Void)?
         var didFocusInitially = false
+        private var lastReportedContentHeight: CGFloat?
 
         init(text: Binding<String>) {
             _text = text
@@ -130,12 +154,33 @@ private struct SourceTextEditor: NSViewRepresentable {
             guard let textView = notification.object as? SubmitAwareTextView else { return }
             textView.refreshDisplay()
             text = textView.string
+            reportContentHeight()
+        }
+
+        @discardableResult
+        func focusTextViewIfPossible() -> Bool {
+            guard let textView, let window = textView.window else { return false }
+            let didFocus = window.makeFirstResponder(textView)
+            didFocusInitially = didFocus
+            return didFocus
+        }
+
+        func reportContentHeight() {
+            guard let textView else { return }
+            let height = textView.measuredContentHeight()
+            guard lastReportedContentHeight.map({ abs($0 - height) > 0.5 }) ?? true else { return }
+            lastReportedContentHeight = height
+            let onContentHeightChange = onContentHeightChange
+            DispatchQueue.main.async {
+                onContentHeightChange?(height)
+            }
         }
     }
 }
 
 private final class SubmitAwareTextView: NSTextView {
     var onSubmit: (() -> Void)?
+    var onCopyAndClose: (() -> Void)?
     private var displayFont: NSFont = .systemFont(ofSize: NSFont.systemFontSize)
 
     func applyDisplayAttributes(font: NSFont) {
@@ -181,10 +226,17 @@ private final class SubmitAwareTextView: NSTextView {
     override func keyDown(with event: NSEvent) {
         let isReturnKey = event.keyCode == 36 || event.keyCode == 76
         let hasShift = event.modifierFlags.contains(.shift)
+        let hasCommand = event.modifierFlags.contains(.command)
 
         // During IME composition (e.g. Chinese Pinyin), Enter should first commit marked text.
-        // Only submit translation when composition has ended.
-        if isReturnKey, !hasShift, !hasMarkedText() {
+        // Only handle Return shortcuts when composition has ended.
+        if isReturnKey, hasCommand, !hasShift, !hasMarkedText() {
+            guard !string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+            onCopyAndClose?()
+            return
+        }
+
+        if isReturnKey, !hasCommand, !hasShift, !hasMarkedText() {
             guard !string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
             onSubmit?()
             return
@@ -224,5 +276,14 @@ private final class SubmitAwareTextView: NSTextView {
         setNeedsDisplay(bounds)
         enclosingScrollView?.contentView.needsDisplay = true
         enclosingScrollView?.needsDisplay = true
+    }
+
+    func measuredContentHeight() -> CGFloat {
+        guard let textContainer, let layoutManager else {
+            return ceil(displayFont.lineHeight)
+        }
+        layoutManager.ensureLayout(for: textContainer)
+        let usedHeight = layoutManager.usedRect(for: textContainer).height
+        return ceil(max(displayFont.lineHeight, usedHeight))
     }
 }

--- a/Sources/Utilities/FontHelper.swift
+++ b/Sources/Utilities/FontHelper.swift
@@ -12,4 +12,8 @@ extension NSFont {
         if name.isEmpty { return .systemFont(ofSize: size) }
         return NSFont(name: name, size: size) ?? .systemFont(ofSize: size)
     }
+
+    var lineHeight: CGFloat {
+        ceil(ascender - descender + leading)
+    }
 }


### PR DESCRIPTION
## Summary
- Focus the popup source input by default whenever translation panels are shown.
- Add ⌘1...⌘9 shortcuts to copy translation results by display order, with copy feedback and delayed auto-dismiss.
- Support ⌘↵ in the source input to copy typed text and close the popup.
- Expand the source input dynamically while capping it at six visible lines.

## Verification
- tuist generate
- xcodebuild -workspace MoePeek.xcworkspace -scheme MoePeek -configuration Debug -derivedDataPath /private/tmp/MoePeekDerivedData build -quiet
