### PR TITLE
Release v0.14.0: popup shortcuts & pin window

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -49,7 +49,7 @@ let project = Project(
                     "CODE_SIGN_STYLE": "$(MOEPEEK_CODE_SIGN_STYLE)",
                     "CODE_SIGN_IDENTITY": "$(MOEPEEK_CODE_SIGN_IDENTITY)",
                     "DEVELOPMENT_TEAM": "$(MOEPEEK_DEVELOPMENT_TEAM)",
-                    "MARKETING_VERSION": "0.13.1",
+                    "MARKETING_VERSION": "0.14.0",
                     "CURRENT_PROJECT_VERSION": "1",
                 ],
                 configurations: [

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -47,11 +47,22 @@
       }
     },
     "↵ Translate · ⇧↵ Newline" : {
+      "extractionState" : "stale",
       "localizations" : {
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "↵ 翻译 · ⇧↵ 换行"
+          }
+        }
+      }
+    },
+    "↵ Translate · ⌘↵ Copy & Close · ⇧↵ Newline" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "↵ 翻译 · ⌘↵ 复制并关闭 · ⇧↵ 换行"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -1477,6 +1477,17 @@
         }
       }
     },
+    "Pin Popup" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "钉住窗口"
+          }
+        }
+      }
+    },
     "Please enter a valid Base URL (starting with http:// or https://) and API Key" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -1785,6 +1796,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "屏幕录制权限"
+          }
+        }
+      }
+    },
+    "Screen recording permission not granted. Open Settings to enable it." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "屏幕录制权限未授权。请前往设置中开启。"
           }
         }
       }
@@ -2292,6 +2314,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未知 DeepLX 错误"
+          }
+        }
+      }
+    },
+    "Unpin Popup" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消钉住窗口"
           }
         }
       }

--- a/Sources/Core/TranslationCoordinator.swift
+++ b/Sources/Core/TranslationCoordinator.swift
@@ -72,13 +72,21 @@ final class TranslationCoordinator {
 
     /// Triggered by OCR shortcut: screen capture → OCR → translate.
     func ocrAndTranslate() async {
+        guard permissionManager.isScreenRecordingGranted else {
+            phase = .active
+            sourceText = ""
+            globalError = String(localized: "Screen recording permission not granted. Open Settings to enable it.")
+            return
+        }
+
+        let previousPhase = phase
         phase = .grabbing
 
         do {
             let text = try await ScreenCaptureOCR.captureAndRecognize()
             translate(text)
-        } catch is OCRError {
-            phase = .idle
+        } catch OCRError.captureCancelled {
+            phase = previousPhase
         } catch {
             phase = .active
             sourceText = ""

--- a/Sources/Core/TranslationCoordinator.swift
+++ b/Sources/Core/TranslationCoordinator.swift
@@ -34,10 +34,13 @@ final class TranslationCoordinator {
     /// Monotonically increasing counter; increments each time `translate()` is called.
     /// Used by PopupView to reset `expandedProviders` for subsequent translations.
     private(set) var translationGeneration: Int = 0
+    private(set) var copiedProviderID: String?
+    private(set) var copyFeedbackGeneration: Int = 0
 
     let registry: TranslationProviderRegistry
     private let permissionManager: PermissionManager
     private var activeTasks: [String: Task<Void, Never>] = [:]
+    private var copyFeedbackTask: Task<Void, Never>?
 
     init(permissionManager: PermissionManager, registry: TranslationProviderRegistry) {
         self.permissionManager = permissionManager
@@ -98,6 +101,7 @@ final class TranslationCoordinator {
     /// Reset state and enter input mode (empty source input for manual typing).
     func prepareInputMode() {
         cancelAll()
+        clearCopyFeedback()
         globalError = nil
         sourceText = ""
         detectedLanguage = nil
@@ -120,6 +124,7 @@ final class TranslationCoordinator {
         }
 
         cancelAll()
+        clearCopyFeedback()
         globalError = nil
 
         sourceText = trimmed
@@ -182,8 +187,27 @@ final class TranslationCoordinator {
         activeTasks[provider.id] = task
     }
 
+    @discardableResult
+    func copyResult(atDisplayIndex index: Int) -> Bool {
+        guard activeSlots.indices.contains(index) else { return false }
+        return copyResult(forProviderID: activeSlots[index].id)
+    }
+
+    @discardableResult
+    func copyResult(forProviderID providerID: String) -> Bool {
+        guard let resultText = providerStates[providerID]?.copyableText,
+              !resultText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else { return false }
+
+        NSPasteboard.general.clearContents()
+        guard NSPasteboard.general.setString(resultText, forType: .string) else { return false }
+        showCopyFeedback(forProviderID: providerID)
+        return true
+    }
+
     func dismiss() {
         cancelAll()
+        clearCopyFeedback()
         phase = .idle
         sourceText = ""
         detectedLanguage = nil
@@ -260,6 +284,26 @@ final class TranslationCoordinator {
         activeTasks.removeAll()
     }
 
+    private func showCopyFeedback(forProviderID providerID: String) {
+        copyFeedbackTask?.cancel()
+        copiedProviderID = providerID
+        copyFeedbackGeneration += 1
+
+        copyFeedbackTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(900))
+            guard !Task.isCancelled else { return }
+            guard self?.copiedProviderID == providerID else { return }
+            self?.copiedProviderID = nil
+            self?.copyFeedbackTask = nil
+        }
+    }
+
+    private func clearCopyFeedback() {
+        copyFeedbackTask?.cancel()
+        copyFeedbackTask = nil
+        copiedProviderID = nil
+    }
+
     /// Build language hints (BCP 47 codes) based on user's target/source language preferences.
     /// Likely source languages are inferred from the target language for common translation pairs.
     private func buildLanguageHints() -> [String: Double]? {
@@ -327,5 +371,18 @@ final class TranslationCoordinator {
         }
 
         return preferred
+    }
+}
+
+private extension TranslationCoordinator.ProviderState {
+    var copyableText: String? {
+        switch self {
+        case let .streaming(partial):
+            partial
+        case let .completed(text):
+            text
+        case .waiting, .translating, .error:
+            nil
+        }
     }
 }

--- a/Sources/Core/TranslationCoordinator.swift
+++ b/Sources/Core/TranslationCoordinator.swift
@@ -26,7 +26,12 @@ final class TranslationCoordinator {
     private(set) var detectedLanguage: String?
     private(set) var targetLanguage: String = ""
     private(set) var providerStates: [String: ProviderState] = [:]
-    private(set) var globalError: String?
+    /// Setting a non-nil error also auto-unpins, so an error never appears in a frozen pinned panel.
+    private(set) var globalError: String? {
+        didSet {
+            if globalError != nil { isPinned = false }
+        }
+    }
     private(set) var detectionResult: DetectionResult?
     /// Snapshot of expanded provider slots for the current translation session.
     /// PopupView reads this instead of `registry.enabledSlots` to avoid recomputation during streaming.
@@ -36,6 +41,8 @@ final class TranslationCoordinator {
     private(set) var translationGeneration: Int = 0
     private(set) var copiedProviderID: String?
     private(set) var copyFeedbackGeneration: Int = 0
+    /// Single source of truth for popup pin state. PopupView toggles, PopupPanelController reads.
+    var isPinned: Bool = false
 
     let registry: TranslationProviderRegistry
     private let permissionManager: PermissionManager
@@ -224,6 +231,7 @@ final class TranslationCoordinator {
         globalError = nil
         detectionResult = nil
         activeSlots = []
+        isPinned = false
     }
 
     // MARK: - Computed Helpers

--- a/Sources/UI/PopupDismissMonitor.swift
+++ b/Sources/UI/PopupDismissMonitor.swift
@@ -4,6 +4,7 @@ import AppKit
 @MainActor
 final class PopupDismissMonitor {
     private let panel: NSPanel
+    private let isPinned: @MainActor () -> Bool
     private let onDismiss: @MainActor () -> Void
 
     nonisolated(unsafe) private var globalClickMonitor: Any?
@@ -11,8 +12,13 @@ final class PopupDismissMonitor {
     nonisolated(unsafe) private var localClickMonitor: Any?
     nonisolated(unsafe) private var localKeyMonitor: Any?
 
-    init(panel: NSPanel, onDismiss: @escaping @MainActor () -> Void) {
+    init(
+        panel: NSPanel,
+        isPinned: @escaping @MainActor () -> Bool = { false },
+        onDismiss: @escaping @MainActor () -> Void
+    ) {
         self.panel = panel
+        self.isPinned = isPinned
         self.onDismiss = onDismiss
     }
 
@@ -22,7 +28,7 @@ final class PopupDismissMonitor {
             matching: [.leftMouseDown, .rightMouseDown]
         ) { [weak self] _ in
             Task { @MainActor in
-                self?.onDismiss()
+                self?.dismissForOutsideClick()
             }
         }
 
@@ -43,12 +49,12 @@ final class PopupDismissMonitor {
             let clickLocation = event.locationInWindow
             if event.window !== self.panel {
                 Task { @MainActor in
-                    self.onDismiss()
+                    self.dismissForOutsideClick()
                 }
             } else if let contentView = self.panel.contentView,
                       !contentView.frame.contains(clickLocation) {
                 Task { @MainActor in
-                    self.onDismiss()
+                    self.dismissForOutsideClick()
                 }
             }
             return event
@@ -63,6 +69,11 @@ final class PopupDismissMonitor {
             }
             return event
         }
+    }
+
+    private func dismissForOutsideClick() {
+        guard !isPinned() else { return }
+        onDismiss()
     }
 
     func stop() {

--- a/Sources/UI/PopupPanel/PopupPanel.swift
+++ b/Sources/UI/PopupPanel/PopupPanel.swift
@@ -15,8 +15,14 @@ extension EnvironmentValues {
     }
 }
 
+enum PopupPanelViewIdentifier {
+    static let sourceInputTextView = "SourceInputTextView"
+}
+
 /// A floating, non-activating panel for showing translation results near the cursor.
 final class PopupPanel: NSPanel {
+    var onCopyResultShortcut: ((Int) -> Bool)?
+
     init(contentRect: NSRect) {
         super.init(
             contentRect: contentRect,
@@ -45,11 +51,26 @@ final class PopupPanel: NSPanel {
     // Allow becoming key window so users can select/copy text within the panel.
     override var canBecomeKey: Bool { true }
 
+    func focusSourceInput(retries: Int = 4) {
+        if focusSourceInputNow() { return }
+        guard retries > 0 else { return }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.03) { [weak self] in
+            self?.focusSourceInput(retries: retries - 1)
+        }
+    }
+
     // MARK: - Selective Window Dragging
 
     /// Intercepts left-mouse-down on non-interactive areas to start a window drag,
     /// while letting interactive controls (text views, buttons, gesture views) handle events normally.
     override func sendEvent(_ event: NSEvent) {
+        if event.type == .keyDown,
+           let resultIndex = copyResultShortcutIndex(for: event),
+           onCopyResultShortcut?(resultIndex) == true {
+            return
+        }
+
         if event.type == .leftMouseDown {
             if shouldStartWindowDrag(for: event) {
                 performDrag(with: event)
@@ -59,6 +80,29 @@ final class PopupPanel: NSPanel {
             if !isKeyWindow { makeKey() }
         }
         super.sendEvent(event)
+    }
+
+    private func copyResultShortcutIndex(for event: NSEvent) -> Int? {
+        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        let disallowedFlags: NSEvent.ModifierFlags = [.shift, .option, .control]
+        guard flags.contains(.command),
+              flags.intersection(disallowedFlags).isEmpty,
+              let characters = event.charactersIgnoringModifiers,
+              characters.count == 1,
+              let number = Int(characters),
+              (1...9).contains(number)
+        else { return nil }
+
+        return number - 1
+    }
+
+    private func focusSourceInputNow() -> Bool {
+        guard let contentView,
+              let textView = findSourceInputTextView(in: contentView)
+        else { return false }
+
+        makeKey()
+        return makeFirstResponder(textView)
     }
 
     private func shouldStartWindowDrag(for event: NSEvent) -> Bool {
@@ -88,5 +132,20 @@ final class PopupPanel: NSPanel {
             if hasInteractiveMarker(in: subview, containing: point) { return true }
         }
         return false
+    }
+
+    private func findSourceInputTextView(in view: NSView) -> NSTextView? {
+        if view.identifier?.rawValue == PopupPanelViewIdentifier.sourceInputTextView,
+           let textView = view as? NSTextView {
+            return textView
+        }
+
+        for subview in view.subviews {
+            if let textView = findSourceInputTextView(in: subview) {
+                return textView
+            }
+        }
+
+        return nil
     }
 }

--- a/Sources/UI/PopupPanel/PopupPanel.swift
+++ b/Sources/UI/PopupPanel/PopupPanel.swift
@@ -69,11 +69,16 @@ final class PopupPanel: NSPanel {
 
     /// Called by `SubmitAwareTextView` once it enters the window hierarchy.
     /// Consumes the one-shot `pendingSourceInputFocus` flag.
+    /// Responder-chain mutation is deferred to the next runloop tick to avoid
+    /// reentering AppKit during the `viewDidMoveToWindow` callback.
     func consumePendingSourceInputFocus(into textView: NSTextView) {
         guard pendingSourceInputFocus else { return }
         pendingSourceInputFocus = false
-        makeKey()
-        _ = makeFirstResponder(textView)
+        Task { @MainActor [weak self, weak textView] in
+            guard let self, let textView, textView.window === self else { return }
+            self.makeKey()
+            _ = self.makeFirstResponder(textView)
+        }
     }
 
     // MARK: - Selective Window Dragging

--- a/Sources/UI/PopupPanel/PopupPanel.swift
+++ b/Sources/UI/PopupPanel/PopupPanel.swift
@@ -23,6 +23,10 @@ enum PopupPanelViewIdentifier {
 final class PopupPanel: NSPanel {
     var onCopyResultShortcut: ((Int) -> Bool)?
 
+    /// Set when `focusSourceInput()` is called before the source text view has been mounted.
+    /// `SubmitAwareTextView.viewDidMoveToWindow` consumes this flag once the view attaches.
+    private(set) var pendingSourceInputFocus = false
+
     init(contentRect: NSRect) {
         super.init(
             contentRect: contentRect,
@@ -51,13 +55,25 @@ final class PopupPanel: NSPanel {
     // Allow becoming key window so users can select/copy text within the panel.
     override var canBecomeKey: Bool { true }
 
-    func focusSourceInput(retries: Int = 4) {
-        if focusSourceInputNow() { return }
-        guard retries > 0 else { return }
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.03) { [weak self] in
-            self?.focusSourceInput(retries: retries - 1)
+    /// Move first responder to the source input text view. If the text view has not
+    /// been mounted yet (SwiftUI renders asynchronously), arms a one-shot flag that
+    /// `SubmitAwareTextView.viewDidMoveToWindow` will consume when the view attaches.
+    func focusSourceInput() {
+        if let contentView, let textView = findSourceInputTextView(in: contentView) {
+            makeKey()
+            _ = makeFirstResponder(textView)
+            return
         }
+        pendingSourceInputFocus = true
+    }
+
+    /// Called by `SubmitAwareTextView` once it enters the window hierarchy.
+    /// Consumes the one-shot `pendingSourceInputFocus` flag.
+    func consumePendingSourceInputFocus(into textView: NSTextView) {
+        guard pendingSourceInputFocus else { return }
+        pendingSourceInputFocus = false
+        makeKey()
+        _ = makeFirstResponder(textView)
     }
 
     // MARK: - Selective Window Dragging
@@ -94,15 +110,6 @@ final class PopupPanel: NSPanel {
         else { return nil }
 
         return number - 1
-    }
-
-    private func focusSourceInputNow() -> Bool {
-        guard let contentView,
-              let textView = findSourceInputTextView(in: contentView)
-        else { return false }
-
-        makeKey()
-        return makeFirstResponder(textView)
     }
 
     private func shouldStartWindowDrag(for event: NSEvent) -> Bool {

--- a/Sources/UI/PopupPanel/PopupPanelController.swift
+++ b/Sources/UI/PopupPanel/PopupPanelController.swift
@@ -9,6 +9,7 @@ final class PopupPanelController {
 
     private var panel: PopupPanel?
     private var dismissMonitor: PopupDismissMonitor?
+    private var isPinned = false
     private var copyShortcutDismissTask: Task<Void, Never>?
 
     private let coordinator: TranslationCoordinator
@@ -31,6 +32,16 @@ final class PopupPanelController {
     func showAtCursor() {
         let initialSize = setupPanel()
         guard let panel else { return }
+
+        if coordinator.globalError != nil {
+            isPinned = false
+        }
+
+        if isPinned, panel.isVisible {
+            panel.orderFront(nil)
+            startDismissMonitor()
+            return
+        }
 
         let cursorPos = NSEvent.mouseLocation
         guard let screen = NSScreen.screens.first(where: { $0.frame.contains(cursorPos) })
@@ -83,6 +94,7 @@ final class PopupPanelController {
         copyShortcutDismissTask = nil
         dismissMonitor?.stop()
         dismissMonitor = nil
+        isPinned = false
         ttsCoordinator?.stop()
         panel?.contentView = nil
         panel?.close()
@@ -103,6 +115,10 @@ final class PopupPanelController {
         panel?.isVisible ?? false
     }
 
+    func setPinned(_ pinned: Bool) {
+        isPinned = pinned
+    }
+
     // MARK: - Private
 
     @discardableResult
@@ -119,6 +135,9 @@ final class PopupPanelController {
             }
             let contentView = PopupView(
                 coordinator: coordinator,
+                onPinnedChange: { [weak self] pinned in
+                    self?.setPinned(pinned)
+                },
                 onDismiss: { [weak self] in
                     self?.dismiss()
                 },
@@ -154,7 +173,11 @@ final class PopupPanelController {
 
     private func startDismissMonitor() {
         guard let panel else { return }
-        dismissMonitor = PopupDismissMonitor(panel: panel) { [weak self] in
+        dismissMonitor?.stop()
+        dismissMonitor = PopupDismissMonitor(
+            panel: panel,
+            isPinned: { [weak self] in self?.isPinned ?? false }
+        ) { [weak self] in
             self?.dismiss()
         }
         dismissMonitor?.start()

--- a/Sources/UI/PopupPanel/PopupPanelController.swift
+++ b/Sources/UI/PopupPanel/PopupPanelController.swift
@@ -9,7 +9,6 @@ final class PopupPanelController {
 
     private var panel: PopupPanel?
     private var dismissMonitor: PopupDismissMonitor?
-    private var isPinned = false
     private var copyShortcutDismissTask: Task<Void, Never>?
 
     private let coordinator: TranslationCoordinator
@@ -33,11 +32,8 @@ final class PopupPanelController {
         let initialSize = setupPanel()
         guard let panel else { return }
 
-        if coordinator.globalError != nil {
-            isPinned = false
-        }
-
-        if isPinned, panel.isVisible {
+        // Coordinator auto-unpins on non-nil globalError via didSet, so checking isPinned alone is safe.
+        if coordinator.isPinned, panel.isVisible {
             panel.orderFront(nil)
             startDismissMonitor()
             return
@@ -94,7 +90,6 @@ final class PopupPanelController {
         copyShortcutDismissTask = nil
         dismissMonitor?.stop()
         dismissMonitor = nil
-        isPinned = false
         ttsCoordinator?.stop()
         panel?.contentView = nil
         panel?.close()
@@ -115,10 +110,6 @@ final class PopupPanelController {
         panel?.isVisible ?? false
     }
 
-    func setPinned(_ pinned: Bool) {
-        isPinned = pinned
-    }
-
     // MARK: - Private
 
     @discardableResult
@@ -135,9 +126,6 @@ final class PopupPanelController {
             }
             let contentView = PopupView(
                 coordinator: coordinator,
-                onPinnedChange: { [weak self] pinned in
-                    self?.setPinned(pinned)
-                },
                 onDismiss: { [weak self] in
                     self?.dismiss()
                 },
@@ -176,7 +164,7 @@ final class PopupPanelController {
         dismissMonitor?.stop()
         dismissMonitor = PopupDismissMonitor(
             panel: panel,
-            isPinned: { [weak self] in self?.isPinned ?? false }
+            isPinned: { [weak self] in self?.coordinator.isPinned ?? false }
         ) { [weak self] in
             self?.dismiss()
         }

--- a/Sources/UI/PopupPanel/PopupPanelController.swift
+++ b/Sources/UI/PopupPanel/PopupPanelController.swift
@@ -9,6 +9,7 @@ final class PopupPanelController {
 
     private var panel: PopupPanel?
     private var dismissMonitor: PopupDismissMonitor?
+    private var copyShortcutDismissTask: Task<Void, Never>?
 
     private let coordinator: TranslationCoordinator
     private let ttsCoordinator: TTSCoordinator?
@@ -27,7 +28,7 @@ final class PopupPanelController {
         self.settingsController = settingsController
     }
 
-    func showAtCursor() {
+    func showAtCursor(focusInput: Bool = true) {
         let initialSize = setupPanel()
         guard let panel else { return }
 
@@ -42,8 +43,15 @@ final class PopupPanelController {
             screen: screen
         )
         panel.setFrame(frame, display: true)
-        // Non-activating: don't steal focus from the user's active app.
-        panel.orderFront(nil)
+        if focusInput {
+            previouslyActiveApp = NSWorkspace.shared.frontmostApplication
+            NSApp.activate(ignoringOtherApps: true)
+            panel.makeKeyAndOrderFront(nil)
+            panel.focusSourceInput()
+        } else {
+            // Non-activating: don't steal focus from the user's active app.
+            panel.orderFront(nil)
+        }
 
         startDismissMonitor()
     }
@@ -70,11 +78,14 @@ final class PopupPanelController {
         previouslyActiveApp = NSWorkspace.shared.frontmostApplication
         NSApp.activate(ignoringOtherApps: true)
         panel.makeKeyAndOrderFront(nil)
+        panel.focusSourceInput()
 
         startDismissMonitor()
     }
 
     func dismiss() {
+        copyShortcutDismissTask?.cancel()
+        copyShortcutDismissTask = nil
         dismissMonitor?.stop()
         dismissMonitor = nil
         ttsCoordinator?.stop()
@@ -108,8 +119,14 @@ final class PopupPanelController {
 
         if panel == nil {
             let newPanel = PopupPanel(contentRect: NSRect(origin: .zero, size: initialSize))
+            newPanel.onCopyResultShortcut = { [weak self] index in
+                self?.copyResultFromShortcut(atDisplayIndex: index) ?? false
+            }
             let contentView = PopupView(
                 coordinator: coordinator,
+                onDismiss: { [weak self] in
+                    self?.dismiss()
+                },
                 onOpenSettings: { [weak self] in
                     self?.dismiss()
                     self?.settingsController?.showWindow()
@@ -126,6 +143,18 @@ final class PopupPanelController {
         }
 
         return initialSize
+    }
+
+    private func copyResultFromShortcut(atDisplayIndex index: Int) -> Bool {
+        guard coordinator.copyResult(atDisplayIndex: index) else { return false }
+
+        copyShortcutDismissTask?.cancel()
+        copyShortcutDismissTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(280))
+            guard !Task.isCancelled else { return }
+            self?.dismiss()
+        }
+        return true
     }
 
     private func startDismissMonitor() {

--- a/Sources/UI/PopupPanel/PopupPanelController.swift
+++ b/Sources/UI/PopupPanel/PopupPanelController.swift
@@ -28,7 +28,7 @@ final class PopupPanelController {
         self.settingsController = settingsController
     }
 
-    func showAtCursor(focusInput: Bool = true) {
+    func showAtCursor() {
         let initialSize = setupPanel()
         guard let panel else { return }
 
@@ -43,15 +43,10 @@ final class PopupPanelController {
             screen: screen
         )
         panel.setFrame(frame, display: true)
-        if focusInput {
-            previouslyActiveApp = NSWorkspace.shared.frontmostApplication
-            NSApp.activate(ignoringOtherApps: true)
-            panel.makeKeyAndOrderFront(nil)
-            panel.focusSourceInput()
-        } else {
-            // Non-activating: don't steal focus from the user's active app.
-            panel.orderFront(nil)
-        }
+        // Non-activating: don't steal focus from the user's active app.
+        // The panel will accept key events (and ⌘1...⌘9 copy shortcuts) once the user clicks
+        // into it, since PopupPanel.canBecomeKey is true.
+        panel.orderFront(nil)
 
         startDismissMonitor()
     }

--- a/Sources/UI/PopupPanel/PopupView.swift
+++ b/Sources/UI/PopupPanel/PopupView.swift
@@ -5,13 +5,11 @@ import SwiftUI
 /// The SwiftUI content displayed inside the popup translation panel.
 struct PopupView: View {
     let coordinator: TranslationCoordinator
-    var onPinnedChange: ((Bool) -> Void)?
     var onDismiss: (() -> Void)?
     var onOpenSettings: (() -> Void)?
     @State private var editableText: String = ""
     @State private var expandedProviders: Set<String> = []
     @State private var autoPlayedGeneration: Int = -1
-    @State private var isPinned = false
     @Environment(\.ttsCoordinator) private var ttsCoordinator
     @State private var sourceLang: String = Defaults[.sourceLanguage]
     @State private var targetLang: String = Defaults[.targetLanguage]
@@ -109,28 +107,18 @@ struct PopupView: View {
         .onChange(of: coordinator.providerStates) { _, newStates in
             handleAutoPlay(states: newStates)
         }
-        .onChange(of: coordinator.globalError) { _, message in
-            guard message != nil, isPinned else { return }
-            isPinned = false
-            onPinnedChange?(false)
-        }
     }
 
     private var pinButton: some View {
         Button {
-            isPinned.toggle()
-            onPinnedChange?(isPinned)
+            coordinator.isPinned.toggle()
         } label: {
-            Image(systemName: isPinned ? "pin.fill" : "pin")
-                .font(.system(size: max(CGFloat(fontSize - 5), 10)))
-                .foregroundStyle(isPinned ? Color.accentColor : Color.secondary)
-                .frame(width: 18, height: 18)
-                .contentShape(Rectangle())
+            Image(systemName: coordinator.isPinned ? "pin.fill" : "pin")
+                .font(.system(size: CGFloat(fontSize - 2)))
+                .foregroundStyle(coordinator.isPinned ? Color.accentColor : Color.secondary)
         }
         .buttonStyle(.plain)
-        .help(isPinned ? "Unpin Popup" : "Pin Popup")
-        .padding(.top, 4)
-        .padding(.trailing, 8)
+        .help(coordinator.isPinned ? "Unpin Popup" : "Pin Popup")
         .background { InteractiveMarker() }
     }
 
@@ -148,113 +136,109 @@ struct PopupView: View {
                 .padding(.horizontal, contentHorizontalPadding)
                 .padding(.vertical, contentHorizontalPadding)
             } else {
-                ZStack(alignment: .topTrailing) {
-                    VStack(alignment: .leading, spacing: 0) {
-                        // Source input
-                        SourceInputView(
-                            text: $editableText,
-                            sourceLanguage: coordinator.detectedLanguage ?? sourceLang,
-                            onSubmit: {
-                                coordinator.translate(editableText)
-                            },
-                            onCopyAndClose: {
-                                copySourceAndClose()
-                            },
-                            onContentHeightChange: { preferredHeight in
-                                expandInputHeightIfNeeded(for: preferredHeight)
-                            }
-                        )
-                        .frame(height: inputHeight)
-                        .padding(.horizontal, contentHorizontalPadding)
-                        .padding(.top, contentHorizontalPadding)
-                        .padding(.bottom, 4)
-
-                        DraggableDividerView(
-                            inputHeight: $inputHeight,
-                            minHeight: inputMinHeight,
-                            maxHeight: maxInputHeight,
-                            horizontalPadding: contentHorizontalPadding,
-                            onDragEnd: { Defaults[.popupInputHeight] = Int(inputHeight) }
-                        )
-
-                        // Language bar + settings button
-                        HStack(spacing: 4) {
-                            LanguageBarView(
-                                sourceLanguage: $sourceLang,
-                                detectedLanguage: coordinator.detectedLanguage,
-                                detectionConfidence: coordinator.detectionResult?.confidence,
-                                targetLanguage: $targetLang,
-                                onSwap: {
-                                    let effectiveSource = sourceLang == "auto"
-                                    ? (coordinator.detectedLanguage ?? targetLang)
-                                    : sourceLang
-                                    // When auto-detect has no result yet, effectiveSource falls back
-                                    // to targetLang and swap becomes a no-op
-                                    guard effectiveSource != targetLang else { return }
-                                    sourceLang = targetLang
-                                    targetLang = effectiveSource
-                                }
-                            )
-
-                            Button {
-                                onOpenSettings?()
-                            } label: {
-                                Image(systemName: "gearshape")
-                                    .font(.system(size: CGFloat(fontSize - 2)))
-                                    .foregroundStyle(.secondary)
-                            }
-                            .buttonStyle(.plain)
-                            .help("Open Settings")
-                            .background { InteractiveMarker() }
-                        }
-                        .padding(.horizontal, contentHorizontalPadding)
-                        .padding(.vertical, 4)
-                        .onChange(of: targetLang) { _, newValue in
-                            Defaults[.targetLanguage] = newValue
-                            // Skip retranslation when this change came from coordinator sync
-                            guard newValue != coordinator.targetLanguage else { return }
-                            if !editableText.isEmpty {
-                                coordinator.translate(editableText)
-                            }
-                        }
-                        .onChange(of: sourceLang) { _, newValue in
-                            Defaults[.sourceLanguage] = newValue
-                            if !editableText.isEmpty {
-                                coordinator.translate(editableText)
-                            }
-                        }
-
-                        Divider()
-                            .padding(.horizontal, contentHorizontalPadding)
-
-                        // Provider results
-                        ScrollView {
-                            VStack(spacing: 6) {
-                                ForEach(coordinator.activeSlots, id: \.id) { provider in
-                                    if let state = coordinator.providerStates[provider.id] {
-                                        ProviderResultCard(
-                                            provider: provider,
-                                            state: state,
-                                            targetLanguage: targetLang,
-                                            isExpanded: expandedBinding(for: provider.id),
-                                            isCopyFeedbackActive: coordinator.copiedProviderID == provider.id,
-                                            copyFeedbackGeneration: coordinator.copyFeedbackGeneration,
-                                            onCopy: {
-                                                coordinator.copyResult(forProviderID: provider.id)
-                                            },
-                                            onRetry: {
-                                                coordinator.retryProvider(provider)
-                                            }
-                                        )
-                                    }
-                                }
-                            }
-                            .padding(.horizontal, contentHorizontalPadding)
-                            .padding(.vertical, 6)
-                        }
+                // Source input
+                SourceInputView(
+                    text: $editableText,
+                    sourceLanguage: coordinator.detectedLanguage ?? sourceLang,
+                    onSubmit: {
+                        coordinator.translate(editableText)
+                    },
+                    onCopyAndClose: {
+                        copySourceAndClose()
+                    },
+                    onContentHeightChange: { preferredHeight in
+                        expandInputHeightIfNeeded(for: preferredHeight)
                     }
+                )
+                .frame(height: inputHeight)
+                .padding(.horizontal, contentHorizontalPadding)
+                .padding(.top, contentHorizontalPadding)
+                .padding(.bottom, 4)
+
+                DraggableDividerView(
+                    inputHeight: $inputHeight,
+                    minHeight: inputMinHeight,
+                    maxHeight: maxInputHeight,
+                    horizontalPadding: contentHorizontalPadding,
+                    onDragEnd: { Defaults[.popupInputHeight] = Int(inputHeight) }
+                )
+
+                // Language bar + settings + pin
+                HStack(spacing: 4) {
+                    LanguageBarView(
+                        sourceLanguage: $sourceLang,
+                        detectedLanguage: coordinator.detectedLanguage,
+                        detectionConfidence: coordinator.detectionResult?.confidence,
+                        targetLanguage: $targetLang,
+                        onSwap: {
+                            let effectiveSource = sourceLang == "auto"
+                            ? (coordinator.detectedLanguage ?? targetLang)
+                            : sourceLang
+                            // When auto-detect has no result yet, effectiveSource falls back
+                            // to targetLang and swap becomes a no-op
+                            guard effectiveSource != targetLang else { return }
+                            sourceLang = targetLang
+                            targetLang = effectiveSource
+                        }
+                    )
+
+                    Button {
+                        onOpenSettings?()
+                    } label: {
+                        Image(systemName: "gearshape")
+                            .font(.system(size: CGFloat(fontSize - 2)))
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Open Settings")
+                    .background { InteractiveMarker() }
 
                     pinButton
+                }
+                .padding(.horizontal, contentHorizontalPadding)
+                .padding(.vertical, 4)
+                .onChange(of: targetLang) { _, newValue in
+                    Defaults[.targetLanguage] = newValue
+                    // Skip retranslation when this change came from coordinator sync
+                    guard newValue != coordinator.targetLanguage else { return }
+                    if !editableText.isEmpty {
+                        coordinator.translate(editableText)
+                    }
+                }
+                .onChange(of: sourceLang) { _, newValue in
+                    Defaults[.sourceLanguage] = newValue
+                    if !editableText.isEmpty {
+                        coordinator.translate(editableText)
+                    }
+                }
+
+                Divider()
+                    .padding(.horizontal, contentHorizontalPadding)
+
+                // Provider results
+                ScrollView {
+                    VStack(spacing: 6) {
+                        ForEach(coordinator.activeSlots, id: \.id) { provider in
+                            if let state = coordinator.providerStates[provider.id] {
+                                ProviderResultCard(
+                                    provider: provider,
+                                    state: state,
+                                    targetLanguage: targetLang,
+                                    isExpanded: expandedBinding(for: provider.id),
+                                    isCopyFeedbackActive: coordinator.copiedProviderID == provider.id,
+                                    copyFeedbackGeneration: coordinator.copyFeedbackGeneration,
+                                    onCopy: {
+                                        coordinator.copyResult(forProviderID: provider.id)
+                                    },
+                                    onRetry: {
+                                        coordinator.retryProvider(provider)
+                                    }
+                                )
+                            }
+                        }
+                    }
+                    .padding(.horizontal, contentHorizontalPadding)
+                    .padding(.vertical, 6)
                 }
             }
         }

--- a/Sources/UI/PopupPanel/PopupView.swift
+++ b/Sources/UI/PopupPanel/PopupView.swift
@@ -5,11 +5,13 @@ import SwiftUI
 /// The SwiftUI content displayed inside the popup translation panel.
 struct PopupView: View {
     let coordinator: TranslationCoordinator
+    var onPinnedChange: ((Bool) -> Void)?
     var onDismiss: (() -> Void)?
     var onOpenSettings: (() -> Void)?
     @State private var editableText: String = ""
     @State private var expandedProviders: Set<String> = []
     @State private var autoPlayedGeneration: Int = -1
+    @State private var isPinned = false
     @Environment(\.ttsCoordinator) private var ttsCoordinator
     @State private var sourceLang: String = Defaults[.sourceLanguage]
     @State private var targetLang: String = Defaults[.targetLanguage]
@@ -107,6 +109,29 @@ struct PopupView: View {
         .onChange(of: coordinator.providerStates) { _, newStates in
             handleAutoPlay(states: newStates)
         }
+        .onChange(of: coordinator.globalError) { _, message in
+            guard message != nil, isPinned else { return }
+            isPinned = false
+            onPinnedChange?(false)
+        }
+    }
+
+    private var pinButton: some View {
+        Button {
+            isPinned.toggle()
+            onPinnedChange?(isPinned)
+        } label: {
+            Image(systemName: isPinned ? "pin.fill" : "pin")
+                .font(.system(size: max(CGFloat(fontSize - 5), 10)))
+                .foregroundStyle(isPinned ? Color.accentColor : Color.secondary)
+                .frame(width: 18, height: 18)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help(isPinned ? "Unpin Popup" : "Pin Popup")
+        .padding(.top, 4)
+        .padding(.trailing, 8)
+        .background { InteractiveMarker() }
     }
 
     // MARK: - Active Content
@@ -123,107 +148,113 @@ struct PopupView: View {
                 .padding(.horizontal, contentHorizontalPadding)
                 .padding(.vertical, contentHorizontalPadding)
             } else {
-                // Source input
-                SourceInputView(
-                    text: $editableText,
-                    sourceLanguage: coordinator.detectedLanguage ?? sourceLang,
-                    onSubmit: {
-                        coordinator.translate(editableText)
-                    },
-                    onCopyAndClose: {
-                        copySourceAndClose()
-                    },
-                    onContentHeightChange: { preferredHeight in
-                        expandInputHeightIfNeeded(for: preferredHeight)
-                    }
-                )
-                .frame(height: inputHeight)
-                .padding(.horizontal, contentHorizontalPadding)
-                .padding(.top, contentHorizontalPadding)
-                .padding(.bottom, 4)
+                ZStack(alignment: .topTrailing) {
+                    VStack(alignment: .leading, spacing: 0) {
+                        // Source input
+                        SourceInputView(
+                            text: $editableText,
+                            sourceLanguage: coordinator.detectedLanguage ?? sourceLang,
+                            onSubmit: {
+                                coordinator.translate(editableText)
+                            },
+                            onCopyAndClose: {
+                                copySourceAndClose()
+                            },
+                            onContentHeightChange: { preferredHeight in
+                                expandInputHeightIfNeeded(for: preferredHeight)
+                            }
+                        )
+                        .frame(height: inputHeight)
+                        .padding(.horizontal, contentHorizontalPadding)
+                        .padding(.top, contentHorizontalPadding)
+                        .padding(.bottom, 4)
 
-                DraggableDividerView(
-                    inputHeight: $inputHeight,
-                    minHeight: inputMinHeight,
-                    maxHeight: maxInputHeight,
-                    horizontalPadding: contentHorizontalPadding,
-                    onDragEnd: { Defaults[.popupInputHeight] = Int(inputHeight) }
-                )
+                        DraggableDividerView(
+                            inputHeight: $inputHeight,
+                            minHeight: inputMinHeight,
+                            maxHeight: maxInputHeight,
+                            horizontalPadding: contentHorizontalPadding,
+                            onDragEnd: { Defaults[.popupInputHeight] = Int(inputHeight) }
+                        )
 
-                // Language bar + settings button
-                HStack(spacing: 4) {
-                    LanguageBarView(
-                        sourceLanguage: $sourceLang,
-                        detectedLanguage: coordinator.detectedLanguage,
-                        detectionConfidence: coordinator.detectionResult?.confidence,
-                        targetLanguage: $targetLang,
-                        onSwap: {
-                            let effectiveSource = sourceLang == "auto"
-                                ? (coordinator.detectedLanguage ?? targetLang)
-                                : sourceLang
-                            // When auto-detect has no result yet, effectiveSource falls back
-                            // to targetLang and swap becomes a no-op
-                            guard effectiveSource != targetLang else { return }
-                            sourceLang = targetLang
-                            targetLang = effectiveSource
+                        // Language bar + settings button
+                        HStack(spacing: 4) {
+                            LanguageBarView(
+                                sourceLanguage: $sourceLang,
+                                detectedLanguage: coordinator.detectedLanguage,
+                                detectionConfidence: coordinator.detectionResult?.confidence,
+                                targetLanguage: $targetLang,
+                                onSwap: {
+                                    let effectiveSource = sourceLang == "auto"
+                                    ? (coordinator.detectedLanguage ?? targetLang)
+                                    : sourceLang
+                                    // When auto-detect has no result yet, effectiveSource falls back
+                                    // to targetLang and swap becomes a no-op
+                                    guard effectiveSource != targetLang else { return }
+                                    sourceLang = targetLang
+                                    targetLang = effectiveSource
+                                }
+                            )
+
+                            Button {
+                                onOpenSettings?()
+                            } label: {
+                                Image(systemName: "gearshape")
+                                    .font(.system(size: CGFloat(fontSize - 2)))
+                                    .foregroundStyle(.secondary)
+                            }
+                            .buttonStyle(.plain)
+                            .help("Open Settings")
+                            .background { InteractiveMarker() }
                         }
-                    )
-
-                    Button {
-                        onOpenSettings?()
-                    } label: {
-                        Image(systemName: "gearshape")
-                            .font(.system(size: CGFloat(fontSize - 2)))
-                            .foregroundStyle(.secondary)
-                    }
-                    .buttonStyle(.plain)
-                    .help("Open Settings")
-                    .background { InteractiveMarker() }
-                }
-                .padding(.horizontal, contentHorizontalPadding)
-                .padding(.vertical, 4)
-                .onChange(of: targetLang) { _, newValue in
-                    Defaults[.targetLanguage] = newValue
-                    // Skip retranslation when this change came from coordinator sync
-                    guard newValue != coordinator.targetLanguage else { return }
-                    if !editableText.isEmpty {
-                        coordinator.translate(editableText)
-                    }
-                }
-                .onChange(of: sourceLang) { _, newValue in
-                    Defaults[.sourceLanguage] = newValue
-                    if !editableText.isEmpty {
-                        coordinator.translate(editableText)
-                    }
-                }
-
-                Divider()
-                    .padding(.horizontal, contentHorizontalPadding)
-
-                // Provider results
-                ScrollView {
-                    VStack(spacing: 6) {
-                        ForEach(coordinator.activeSlots, id: \.id) { provider in
-                            if let state = coordinator.providerStates[provider.id] {
-                                ProviderResultCard(
-                                    provider: provider,
-                                    state: state,
-                                    targetLanguage: targetLang,
-                                    isExpanded: expandedBinding(for: provider.id),
-                                    isCopyFeedbackActive: coordinator.copiedProviderID == provider.id,
-                                    copyFeedbackGeneration: coordinator.copyFeedbackGeneration,
-                                    onCopy: {
-                                        coordinator.copyResult(forProviderID: provider.id)
-                                    },
-                                    onRetry: {
-                                        coordinator.retryProvider(provider)
-                                    }
-                                )
+                        .padding(.horizontal, contentHorizontalPadding)
+                        .padding(.vertical, 4)
+                        .onChange(of: targetLang) { _, newValue in
+                            Defaults[.targetLanguage] = newValue
+                            // Skip retranslation when this change came from coordinator sync
+                            guard newValue != coordinator.targetLanguage else { return }
+                            if !editableText.isEmpty {
+                                coordinator.translate(editableText)
                             }
                         }
+                        .onChange(of: sourceLang) { _, newValue in
+                            Defaults[.sourceLanguage] = newValue
+                            if !editableText.isEmpty {
+                                coordinator.translate(editableText)
+                            }
+                        }
+
+                        Divider()
+                            .padding(.horizontal, contentHorizontalPadding)
+
+                        // Provider results
+                        ScrollView {
+                            VStack(spacing: 6) {
+                                ForEach(coordinator.activeSlots, id: \.id) { provider in
+                                    if let state = coordinator.providerStates[provider.id] {
+                                        ProviderResultCard(
+                                            provider: provider,
+                                            state: state,
+                                            targetLanguage: targetLang,
+                                            isExpanded: expandedBinding(for: provider.id),
+                                            isCopyFeedbackActive: coordinator.copiedProviderID == provider.id,
+                                            copyFeedbackGeneration: coordinator.copyFeedbackGeneration,
+                                            onCopy: {
+                                                coordinator.copyResult(forProviderID: provider.id)
+                                            },
+                                            onRetry: {
+                                                coordinator.retryProvider(provider)
+                                            }
+                                        )
+                                    }
+                                }
+                            }
+                            .padding(.horizontal, contentHorizontalPadding)
+                            .padding(.vertical, 6)
+                        }
                     }
-                    .padding(.horizontal, contentHorizontalPadding)
-                    .padding(.vertical, 6)
+
+                    pinButton
                 }
             }
         }

--- a/Sources/UI/PopupPanel/PopupView.swift
+++ b/Sources/UI/PopupPanel/PopupView.swift
@@ -251,10 +251,13 @@ struct PopupView: View {
         inputHeight = clamped
     }
 
+    /// Reflow the input height to follow content. Grows up to `maxInputHeight` and
+    /// shrinks back down to the user-set baseline (persisted in `popupInputHeight`),
+    /// so deleting pasted long text reclaims the space.
     private func expandInputHeightIfNeeded(for preferredHeight: CGFloat) {
-        clampInputHeightToAllowedRange()
-        let targetHeight = min(max(preferredHeight, inputMinHeight), maxInputHeight)
-        guard targetHeight > inputHeight else { return }
+        let baseline = min(max(CGFloat(Defaults[.popupInputHeight]), inputMinHeight), maxInputHeight)
+        let targetHeight = min(max(preferredHeight, baseline), maxInputHeight)
+        guard abs(targetHeight - inputHeight) > 0.5 else { return }
         inputHeight = targetHeight
     }
 

--- a/Sources/UI/PopupPanel/PopupView.swift
+++ b/Sources/UI/PopupPanel/PopupView.swift
@@ -1,9 +1,11 @@
+import AppKit
 import Defaults
 import SwiftUI
 
 /// The SwiftUI content displayed inside the popup translation panel.
 struct PopupView: View {
     let coordinator: TranslationCoordinator
+    var onDismiss: (() -> Void)?
     var onOpenSettings: (() -> Void)?
     @State private var editableText: String = ""
     @State private var expandedProviders: Set<String> = []
@@ -14,13 +16,21 @@ struct PopupView: View {
     @State private var inputHeight: CGFloat = CGFloat(Defaults[.popupInputHeight])
     @State private var containerHeight: CGFloat = CGFloat(Defaults[.popupDefaultHeight])
     @Default(.popupFontSize) private var fontSize
+    @Default(.popupFontName) private var fontName
 
     private let inputMinHeight: CGFloat = 36
     private let contentHorizontalPadding: CGFloat = 14
 
+    private var inputSixLineHeight: CGFloat {
+        let editorLineHeight = NSFont.popup(name: fontName, size: CGFloat(fontSize)).lineHeight
+        let hintLineHeight = NSFont.popup(name: fontName, size: max(CGFloat(fontSize - 4), 8)).lineHeight
+        return ceil(editorLineHeight * 6 + hintLineHeight + 8)
+    }
+
     private var maxInputHeight: CGFloat {
-        // Reserve 120pt for language bar + results; floor ensures drag range above inputMinHeight
-        max(containerHeight - 120, inputMinHeight + 24)
+        // Reserve 120pt for language bar + results, while capping the editor at six visible lines.
+        let availableHeight = max(containerHeight - 120, inputMinHeight)
+        return max(inputMinHeight, min(inputSixLineHeight, availableHeight))
     }
 
     var body: some View {
@@ -52,9 +62,7 @@ struct PopupView: View {
             }
         )
         .onChange(of: containerHeight) { _, _ in
-            let clamped = min(inputHeight, maxInputHeight)
-            guard clamped != inputHeight else { return }
-            inputHeight = clamped
+            clampInputHeightToAllowedRange()
         }
         .overlay(alignment: .bottomTrailing) {
             ResizeGripView()
@@ -79,6 +87,7 @@ struct PopupView: View {
             sourceLang = Defaults[.sourceLanguage]
             targetLang = coordinator.targetLanguage
             expandedProviders = Set(coordinator.activeSlots.map(\.id))
+            clampInputHeightToAllowedRange()
 
             if Defaults[.ttsAutoPlaySource],
                !coordinator.sourceText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
@@ -90,6 +99,10 @@ struct PopupView: View {
         }
         .onChange(of: coordinator.translationGeneration) { _, _ in
             expandedProviders = Set(coordinator.activeSlots.map(\.id))
+        }
+        .onChange(of: coordinator.copiedProviderID) { _, providerID in
+            guard let providerID else { return }
+            expandedProviders.insert(providerID)
         }
         .onChange(of: coordinator.providerStates) { _, newStates in
             handleAutoPlay(states: newStates)
@@ -116,6 +129,12 @@ struct PopupView: View {
                     sourceLanguage: coordinator.detectedLanguage ?? sourceLang,
                     onSubmit: {
                         coordinator.translate(editableText)
+                    },
+                    onCopyAndClose: {
+                        copySourceAndClose()
+                    },
+                    onContentHeightChange: { preferredHeight in
+                        expandInputHeightIfNeeded(for: preferredHeight)
                     }
                 )
                 .frame(height: inputHeight)
@@ -191,6 +210,11 @@ struct PopupView: View {
                                     state: state,
                                     targetLanguage: targetLang,
                                     isExpanded: expandedBinding(for: provider.id),
+                                    isCopyFeedbackActive: coordinator.copiedProviderID == provider.id,
+                                    copyFeedbackGeneration: coordinator.copyFeedbackGeneration,
+                                    onCopy: {
+                                        coordinator.copyResult(forProviderID: provider.id)
+                                    },
                                     onRetry: {
                                         coordinator.retryProvider(provider)
                                     }
@@ -219,6 +243,27 @@ struct PopupView: View {
                 }
             }
         )
+    }
+
+    private func clampInputHeightToAllowedRange() {
+        let clamped = min(max(inputHeight, inputMinHeight), maxInputHeight)
+        guard clamped != inputHeight else { return }
+        inputHeight = clamped
+    }
+
+    private func expandInputHeightIfNeeded(for preferredHeight: CGFloat) {
+        clampInputHeightToAllowedRange()
+        let targetHeight = min(max(preferredHeight, inputMinHeight), maxInputHeight)
+        guard targetHeight > inputHeight else { return }
+        inputHeight = targetHeight
+    }
+
+    private func copySourceAndClose() {
+        let source = editableText
+        guard !source.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        NSPasteboard.general.clearContents()
+        guard NSPasteboard.general.setString(source, forType: .string) else { return }
+        onDismiss?()
     }
 
     private func handleAutoPlay(states: [String: TranslationCoordinator.ProviderState]) {
@@ -252,7 +297,6 @@ struct PopupView: View {
             tts.speak(text, language: targetLang)
         }
     }
-
 }
 
 // MARK: - Resize Grip

--- a/Sources/UI/PopupPanel/ProviderResultCard.swift
+++ b/Sources/UI/PopupPanel/ProviderResultCard.swift
@@ -7,7 +7,11 @@ struct ProviderResultCard: View {
     let state: TranslationCoordinator.ProviderState
     let targetLanguage: String
     @Binding var isExpanded: Bool
+    let isCopyFeedbackActive: Bool
+    let copyFeedbackGeneration: Int
+    var onCopy: (() -> Void)?
     var onRetry: (() -> Void)?
+    @State private var isCopyPulsing = false
     @Default(.popupFontSize) private var fontSize
     @Default(.popupFontName) private var fontName
     @Default(.ttsAccent) private var ttsAccent
@@ -61,6 +65,18 @@ struct ProviderResultCard: View {
             RoundedRectangle(cornerRadius: 6)
                 .stroke(Color.primary.opacity(0.06), lineWidth: 0.5)
         )
+        .onChange(of: copyFeedbackGeneration) { _, _ in
+            guard isCopyFeedbackActive else { return }
+            withAnimation(.spring(response: 0.18, dampingFraction: 0.55)) {
+                isCopyPulsing = true
+            }
+            Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(180))
+                withAnimation(.spring(response: 0.22, dampingFraction: 0.8)) {
+                    isCopyPulsing = false
+                }
+            }
+        }
     }
 
     private func isSpeaking(_ text: String) -> Bool {
@@ -107,58 +123,9 @@ struct ProviderResultCard: View {
                 .font(.popup(name: fontName, size: CGFloat(fontSize)))
                 .foregroundStyle(.secondary)
         case let .streaming(partial):
-            VStack(alignment: .leading, spacing: 4) {
-                Text(partial)
-                    .font(.popup(name: fontName, size: CGFloat(fontSize)))
-                    .foregroundStyle(.primary)
-                    .textSelection(.enabled)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-            }
-            .background { InteractiveMarker() }
+            resultContent(partial, canSpeak: false)
         case let .completed(text):
-            VStack(alignment: .leading, spacing: 4) {
-                Text(text)
-                    .font(.popup(name: fontName, size: CGFloat(fontSize)))
-                    .foregroundStyle(.primary)
-                    .textSelection(.enabled)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                HStack {
-                    Spacer()
-
-                    if let ttsCoordinator {
-                        Button {
-                            if isSpeaking(text) {
-                                ttsCoordinator.stop()
-                            } else {
-                                ttsCoordinator.speak(text, language: targetLanguage)
-                            }
-                        } label: {
-                            HStack(spacing: 2) {
-                                Image(systemName: isSpeaking(text) ? "speaker.wave.3.fill" : "speaker.wave.2")
-                                if targetLanguage.hasPrefix("en") {
-                                    Text(ttsAccent.shortLabel)
-                                }
-                            }
-                            .font(.popup(name: fontName, size: CGFloat(fontSize - 2)))
-                        }
-                        .buttonStyle(.bordered)
-                        .controlSize(.mini)
-                        .help("Speak")
-                    }
-
-                    Button {
-                        NSPasteboard.general.clearContents()
-                        NSPasteboard.general.setString(text, forType: .string)
-                    } label: {
-                        Label("Copy", systemImage: "doc.on.doc")
-                            .font(.popup(name: fontName, size: CGFloat(fontSize - 2)))
-                    }
-                    .buttonStyle(.bordered)
-                    .controlSize(.mini)
-                }
-            }
-            .background { InteractiveMarker() }
+            resultContent(text, canSpeak: true)
         case let .error(message):
             VStack(alignment: .leading, spacing: 4) {
                 Label(message, systemImage: "exclamationmark.triangle")
@@ -179,5 +146,58 @@ struct ProviderResultCard: View {
             }
             .background { InteractiveMarker() }
         }
+    }
+
+    private func resultContent(_ text: String, canSpeak: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(text)
+                .font(.popup(name: fontName, size: CGFloat(fontSize)))
+                .foregroundStyle(.primary)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            if (canSpeak && ttsCoordinator != nil) || onCopy != nil {
+                HStack {
+                    Spacer()
+
+                    if canSpeak, let ttsCoordinator {
+                        Button {
+                            if isSpeaking(text) {
+                                ttsCoordinator.stop()
+                            } else {
+                                ttsCoordinator.speak(text, language: targetLanguage)
+                            }
+                        } label: {
+                            HStack(spacing: 2) {
+                                Image(systemName: isSpeaking(text) ? "speaker.wave.3.fill" : "speaker.wave.2")
+                                if targetLanguage.hasPrefix("en") {
+                                    Text(ttsAccent.shortLabel)
+                                }
+                            }
+                            .font(.popup(name: fontName, size: CGFloat(fontSize - 2)))
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.mini)
+                        .help("Speak")
+                    }
+
+                    if let onCopy {
+                        Button(action: onCopy) {
+                            Label(
+                                isCopyFeedbackActive ? "Copied" : "Copy",
+                                systemImage: isCopyFeedbackActive ? "checkmark" : "doc.on.doc"
+                            )
+                            .font(.popup(name: fontName, size: CGFloat(fontSize - 2)))
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.mini)
+                        .tint(isCopyFeedbackActive ? .green : nil)
+                        .scaleEffect(isCopyPulsing ? 1.08 : 1)
+                        .animation(.easeInOut(duration: 0.12), value: isCopyFeedbackActive)
+                    }
+                }
+            }
+        }
+        .background { InteractiveMarker() }
     }
 }

--- a/Sources/UI/PopupPanel/ProviderResultCard.swift
+++ b/Sources/UI/PopupPanel/ProviderResultCard.swift
@@ -12,6 +12,7 @@ struct ProviderResultCard: View {
     var onCopy: (() -> Void)?
     var onRetry: (() -> Void)?
     @State private var isCopyPulsing = false
+    @State private var pulseTask: Task<Void, Never>?
     @Default(.popupFontSize) private var fontSize
     @Default(.popupFontName) private var fontName
     @Default(.ttsAccent) private var ttsAccent
@@ -67,15 +68,21 @@ struct ProviderResultCard: View {
         )
         .onChange(of: copyFeedbackGeneration) { _, _ in
             guard isCopyFeedbackActive else { return }
+            pulseTask?.cancel()
             withAnimation(.spring(response: 0.18, dampingFraction: 0.55)) {
                 isCopyPulsing = true
             }
-            Task { @MainActor in
+            pulseTask = Task { @MainActor in
                 try? await Task.sleep(for: .milliseconds(180))
+                guard !Task.isCancelled else { return }
                 withAnimation(.spring(response: 0.22, dampingFraction: 0.8)) {
                     isCopyPulsing = false
                 }
             }
+        }
+        .onDisappear {
+            pulseTask?.cancel()
+            pulseTask = nil
         }
     }
 

--- a/Sources/UI/PopupPanel/SourceInputView.swift
+++ b/Sources/UI/PopupPanel/SourceInputView.swift
@@ -7,6 +7,8 @@ struct SourceInputView: View {
     @Binding var text: String
     let sourceLanguage: String
     let onSubmit: () -> Void
+    let onCopyAndClose: () -> Void
+    var onContentHeightChange: ((CGFloat) -> Void)?
     @Default(.popupFontSize) private var fontSize
     @Default(.popupFontName) private var fontName
     @Default(.ttsAccent) private var ttsAccent
@@ -18,7 +20,11 @@ struct SourceInputView: View {
                 text: $text,
                 fontSize: CGFloat(fontSize),
                 fontName: fontName,
-                onSubmit: onSubmit
+                onSubmit: onSubmit,
+                onCopyAndClose: onCopyAndClose,
+                onContentHeightChange: { editorHeight in
+                    onContentHeightChange?(sourceInputHeight(forEditorHeight: editorHeight))
+                }
             )
                 .frame(maxHeight: .infinity)
                 .background { InteractiveMarker() }
@@ -51,11 +57,17 @@ struct SourceInputView: View {
 
                 Spacer()
 
-                Text("↵ Translate · ⇧↵ Newline")
+                Text("↵ Translate · ⌘↵ Copy & Close · ⇧↵ Newline")
                     .font(.popup(name: fontName, size: CGFloat(fontSize - 4)))
                     .foregroundStyle(.quaternary)
             }
         }
+    }
+
+    private func sourceInputHeight(forEditorHeight editorHeight: CGFloat) -> CGFloat {
+        let hintSize = max(CGFloat(fontSize - 4), 8)
+        let hintHeight = NSFont.popup(name: fontName, size: hintSize).lineHeight
+        return ceil(editorHeight + hintHeight + 8)
     }
 }
 
@@ -64,6 +76,8 @@ private struct SourceTextEditor: NSViewRepresentable {
     let fontSize: CGFloat
     let fontName: String
     let onSubmit: () -> Void
+    let onCopyAndClose: () -> Void
+    let onContentHeightChange: (CGFloat) -> Void
 
     private var resolvedFont: NSFont {
         .popup(name: fontName, size: fontSize)
@@ -74,6 +88,7 @@ private struct SourceTextEditor: NSViewRepresentable {
     }
 
     func makeNSView(context: Context) -> NSScrollView {
+        let coordinator = context.coordinator
         let scrollView = NSScrollView()
         scrollView.borderType = .noBorder
         scrollView.hasVerticalScroller = true
@@ -84,6 +99,7 @@ private struct SourceTextEditor: NSViewRepresentable {
 
         let contentSize = scrollView.contentSize
         let textView = SubmitAwareTextView(frame: NSRect(origin: .zero, size: contentSize))
+        textView.identifier = NSUserInterfaceItemIdentifier(PopupPanelViewIdentifier.sourceInputTextView)
         textView.isRichText = false
         textView.isAutomaticQuoteSubstitutionEnabled = false
         textView.isAutomaticDashSubstitutionEnabled = false
@@ -101,9 +117,10 @@ private struct SourceTextEditor: NSViewRepresentable {
         textView.isVerticallyResizable = true
         textView.isHorizontallyResizable = false
         textView.autoresizingMask = [.width]
-        textView.delegate = context.coordinator
+        textView.delegate = coordinator
         textView.textContainerInset = .zero
         textView.onSubmit = onSubmit
+        textView.onCopyAndClose = onCopyAndClose
         textView.textContainer?.containerSize = NSSize(
             width: contentSize.width,
             height: CGFloat.greatestFiniteMagnitude
@@ -114,11 +131,12 @@ private struct SourceTextEditor: NSViewRepresentable {
         textView.setExternalText(text)
 
         scrollView.documentView = textView
-        context.coordinator.textView = textView
+        coordinator.textView = textView
+        coordinator.onContentHeightChange = onContentHeightChange
 
-        DispatchQueue.main.async {
-            guard let window = textView.window else { return }
-            window.makeFirstResponder(textView)
+        Task { @MainActor in
+            coordinator.reportContentHeight()
+            coordinator.focusTextViewIfPossible()
         }
 
         return scrollView
@@ -127,6 +145,8 @@ private struct SourceTextEditor: NSViewRepresentable {
     func updateNSView(_ nsView: NSScrollView, context: Context) {
         guard let textView = context.coordinator.textView else { return }
 
+        let coordinator = context.coordinator
+        coordinator.onContentHeightChange = onContentHeightChange
         textView.applyDisplayAttributes(font: resolvedFont)
         textView.updateLayout(for: nsView.contentSize)
 
@@ -135,20 +155,24 @@ private struct SourceTextEditor: NSViewRepresentable {
         }
 
         textView.onSubmit = onSubmit
+        textView.onCopyAndClose = onCopyAndClose
 
-        if !context.coordinator.didFocusInitially {
-            context.coordinator.didFocusInitially = true
-            DispatchQueue.main.async {
-                guard let window = textView.window else { return }
-                window.makeFirstResponder(textView)
+        if !coordinator.didFocusInitially {
+            Task { @MainActor in
+                coordinator.focusTextViewIfPossible()
             }
         }
+
+        coordinator.reportContentHeight()
     }
 
+    @MainActor
     final class Coordinator: NSObject, NSTextViewDelegate {
         @Binding var text: String
         weak var textView: SubmitAwareTextView?
+        var onContentHeightChange: ((CGFloat) -> Void)?
         var didFocusInitially = false
+        private var lastReportedContentHeight: CGFloat?
 
         init(text: Binding<String>) {
             _text = text
@@ -158,12 +182,33 @@ private struct SourceTextEditor: NSViewRepresentable {
             guard let textView = notification.object as? SubmitAwareTextView else { return }
             textView.refreshDisplay()
             text = textView.string
+            reportContentHeight()
+        }
+
+        @discardableResult
+        func focusTextViewIfPossible() -> Bool {
+            guard let textView, let window = textView.window else { return false }
+            let didFocus = window.makeFirstResponder(textView)
+            didFocusInitially = didFocus
+            return didFocus
+        }
+
+        func reportContentHeight() {
+            guard let textView else { return }
+            let height = textView.measuredContentHeight()
+            guard lastReportedContentHeight.map({ abs($0 - height) > 0.5 }) ?? true else { return }
+            lastReportedContentHeight = height
+            let onContentHeightChange = onContentHeightChange
+            DispatchQueue.main.async {
+                onContentHeightChange?(height)
+            }
         }
     }
 }
 
 private final class SubmitAwareTextView: NSTextView {
     var onSubmit: (() -> Void)?
+    var onCopyAndClose: (() -> Void)?
     private var displayFont: NSFont = .systemFont(ofSize: NSFont.systemFontSize)
 
     func applyDisplayAttributes(font: NSFont) {
@@ -209,10 +254,17 @@ private final class SubmitAwareTextView: NSTextView {
     override func keyDown(with event: NSEvent) {
         let isReturnKey = event.keyCode == 36 || event.keyCode == 76
         let hasShift = event.modifierFlags.contains(.shift)
+        let hasCommand = event.modifierFlags.contains(.command)
 
         // During IME composition (e.g. Chinese Pinyin), Enter should first commit marked text.
-        // Only submit translation when composition has ended.
-        if isReturnKey, !hasShift, !hasMarkedText() {
+        // Only handle Return shortcuts when composition has ended.
+        if isReturnKey, hasCommand, !hasShift, !hasMarkedText() {
+            guard !string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+            onCopyAndClose?()
+            return
+        }
+
+        if isReturnKey, !hasCommand, !hasShift, !hasMarkedText() {
             guard !string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
             onSubmit?()
             return
@@ -252,5 +304,14 @@ private final class SubmitAwareTextView: NSTextView {
         setNeedsDisplay(bounds)
         enclosingScrollView?.contentView.needsDisplay = true
         enclosingScrollView?.needsDisplay = true
+    }
+
+    func measuredContentHeight() -> CGFloat {
+        guard let textContainer, let layoutManager else {
+            return ceil(displayFont.lineHeight)
+        }
+        layoutManager.ensureLayout(for: textContainer)
+        let usedHeight = layoutManager.usedRect(for: textContainer).height
+        return ceil(max(displayFont.lineHeight, usedHeight))
     }
 }

--- a/Sources/UI/PopupPanel/SourceInputView.swift
+++ b/Sources/UI/PopupPanel/SourceInputView.swift
@@ -134,9 +134,11 @@ private struct SourceTextEditor: NSViewRepresentable {
         coordinator.textView = textView
         coordinator.onContentHeightChange = onContentHeightChange
 
+        // First-responder is established by `SubmitAwareTextView.viewDidMoveToWindow`
+        // (event-driven, no polling). Initial content height is reported here as soon
+        // as layout settles.
         Task { @MainActor in
             coordinator.reportContentHeight()
-            coordinator.focusTextViewIfPossible()
         }
 
         return scrollView
@@ -157,12 +159,6 @@ private struct SourceTextEditor: NSViewRepresentable {
         textView.onSubmit = onSubmit
         textView.onCopyAndClose = onCopyAndClose
 
-        if !coordinator.didFocusInitially {
-            Task { @MainActor in
-                coordinator.focusTextViewIfPossible()
-            }
-        }
-
         coordinator.reportContentHeight()
     }
 
@@ -171,7 +167,6 @@ private struct SourceTextEditor: NSViewRepresentable {
         @Binding var text: String
         weak var textView: SubmitAwareTextView?
         var onContentHeightChange: ((CGFloat) -> Void)?
-        var didFocusInitially = false
         private var lastReportedContentHeight: CGFloat?
 
         init(text: Binding<String>) {
@@ -183,14 +178,6 @@ private struct SourceTextEditor: NSViewRepresentable {
             textView.refreshDisplay()
             text = textView.string
             reportContentHeight()
-        }
-
-        @discardableResult
-        func focusTextViewIfPossible() -> Bool {
-            guard let textView, let window = textView.window else { return false }
-            let didFocus = window.makeFirstResponder(textView)
-            didFocusInitially = didFocus
-            return didFocus
         }
 
         func reportContentHeight() {
@@ -249,6 +236,14 @@ private final class SubmitAwareTextView: NSTextView {
     override func viewDidChangeEffectiveAppearance() {
         super.viewDidChangeEffectiveAppearance()
         applyDisplayAttributes(font: displayFont)
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        // Event-driven first responder handoff: when SwiftUI mounts this text view into
+        // the panel, consume the panel's one-shot focus request set by `focusSourceInput()`.
+        guard let panel = window as? PopupPanel else { return }
+        panel.consumePendingSourceInputFocus(into: self)
     }
 
     override func keyDown(with event: NSEvent) {

--- a/Sources/Utilities/FontHelper.swift
+++ b/Sources/Utilities/FontHelper.swift
@@ -12,4 +12,8 @@ extension NSFont {
         if name.isEmpty { return .systemFont(ofSize: size) }
         return NSFont(name: name, size: size) ?? .systemFont(ofSize: size)
     }
+
+    var lineHeight: CGFloat {
+        ceil(ascender - descender + leading)
+    }
 }


### PR DESCRIPTION
## Summary

Popup 翻译面板交互大版本：⌘1..⌘9 复制结果 / ⌘↵ 复制源文并关闭 / 右上角 pin 按钮窗口置顶 / 输入框自适应。准备发布 v0.14.0。

> **注**：PR #64 需先合并到 dev，此 release PR 才能完整包含其内容。冲突已由 maintainer 本地解决并 push 回 `JimssM/feat/fixed-up`。

## Included PRs

### #65 `feat(Popup): improve translation popup shortcuts` by @qingx2
- **⌘1..⌘9 复制结果**：按显示顺序复制对应 Provider 翻译结果，复制后 280ms 自动关闭弹窗
- **⌘↵ 复制源文并关闭**：源输入框中触发，绕过翻译
- **复制反馈动画**：Copy 按钮 → Copied + 绿色高亮 + 脉冲动画，900ms 后复位
- **输入框自适应**：跟随内容高度，上限 6 行
- **源输入框默认焦点**：手动输入模式自动 makeFirstResponder

### #64 `feat(Popup): pin window button` by @JimssM
- **右上角 Pin 按钮**：钉住弹窗后外部点击不消解
- **错误窗口自动取消钉住**：`globalError` 出现时复位
- **OCR 改进**（顺带）：
  - 加 screen recording 权限前置检查 + 引导报错
  - 区分 `OCRError.captureCancelled`（还原 phase）vs 其他 OCR 错误（显示）
- 关联 issue #60

## Follow-up Fixes (合并 #64 时本地解冲突 + dev follow-up)

- **`fix(PopupPanel): restore non-activating panel contract`** — PR #65 默认在 `showAtCursor` 中激活 app 抢焦点，违反 CLAUDE.md 明文 \"non-activating NSPanels\" 设计。恢复 `panel.orderFront(nil)`。⌘1..⌘9 路径仍可用：`canBecomeKey=true` 让用户点击面板后变 key window。
- **`refactor(Focus): event-driven first responder handoff`** — 删除 `focusSourceInput(retries:)` 的 `DispatchQueue.asyncAfter` 重试轮询。改为一次性 `pendingSourceInputFocus` flag + `SubmitAwareTextView.viewDidMoveToWindow` 消费。无轮询、无重试。
- **`feat(Input): allow input height to shrink back`** — `expandInputHeightIfNeeded` 加缩回逻辑，以 `Defaults[.popupInputHeight]` 为基准，删除粘贴长文后高度可回到用户基线（而非永久撑高）。
- **`i18n(zh-Hans): translate new copy & close hint`** — 新增 `↵ Translate · ⌘↵ Copy & Close · ⇧↵ Newline` 简体中文。
- **`refactor(PopupPanel): tighten access control`** — `pendingSourceInputFocus` 设为 `private(set)`。

## Conflict Resolution (PR #64 ↔ dev)

`PopupPanelController.swift` / `PopupView.swift` 两文件冲突已本地解决：
- 控制器同时持有 `isPinned`（#64）+ `copyShortcutDismissTask`（#65）
- PopupView 同时接受 `onPinnedChange`（#64）+ `onDismiss`（#65）+ `onOpenSettings` 回调
- 源输入 + 翻译结果包裹在 `ZStack(.topTrailing)` 中，pinButton 作为 overlay；同时 SourceInputView 接受 `onCopyAndClose` / `onContentHeightChange`；ProviderResultCard 接受 `isCopyFeedbackActive` / `copyFeedbackGeneration` / `onCopy`

合后 build verified。

## Version

- `chore: bump version to 0.14.0` — 0.13.1 → 0.14.0（SemVer 0.x 阶段新特性 MINOR bump）

## Verification

- ✅ \`tuist generate\`
- ✅ \`xcodebuild -workspace MoePeek.xcworkspace -scheme MoePeek -configuration Debug build\` → BUILD SUCCEEDED
- ✅ Swift 6 strict concurrency complete
- ✅ 无中文注释

## Test Plan

### 划词 / 剪贴板 / OCR / URL scheme 翻译
- [ ] 弹窗出现，当前 app 焦点不被抢走
- [ ] OCR 权限缺失时弹窗内提示 \"Screen recording permission not granted\"
- [ ] OCR 截图取消（ESC）时弹窗回到调用前状态（idle 时关闭，已开弹窗时保留原内容）
- [ ] OCR 截图无文字时显示错误而非静默关闭

### ⌘1..⌘9 / ⌘↵ 复制快捷键
- [ ] 点击面板后按 ⌘1 复制第 1 个 Provider 结果，280ms 内弹窗关闭
- [ ] Copy 按钮：点击后变 Copied 状态 + 脉冲动画 + 900ms 后复位
- [ ] ⌘↵ 在源输入框：复制源文并关闭弹窗

### Pin 按钮
- [ ] 点击右上角 Pin 图标 → pin.fill 变色 → 外部点击不消解
- [ ] 再点取消钉住 → 外部点击恢复消解
- [ ] 翻译出错（`globalError`）时自动取消钉住
- [ ] 弹窗钉住时再次触发翻译，弹窗位置不重定位

### 手动输入模式
- [ ] 默认快捷键触发 → 弹窗出现且源输入框立即获取焦点，可直接打字
- [ ] 输入框扩缩：粘贴长文 → 撑高（至 6 行上限）；删除内容 → 缩回基准高度
- [ ] 拖动 divider 调整输入框高度 → 写盘成新基准

### i18n
- [ ] 中文 UI：hint 显示 \"↵ 翻译 · ⌘↵ 复制并关闭 · ⇧↵ 换行\"
- [ ] 中文 UI：Pin 按钮 tooltip 显示 \"钉住窗口\" / \"取消钉住窗口\"

## Post-merge

1. 合 PR #64 → dev（解冲突后已 CLEAN，可直接合）
2. PR #69 自动包含 #64 改动
3. Merge PR #69 → main
4. 打 tag \`v0.14.0\` 触发 CI 构建发版（见 \`docs/RELEASING.md\`）