### PR TITLE
feat(popup): remember last dragged panel position (#61)

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -1638,6 +1638,7 @@
       }
     },
     "Remember Last Popup Position" : {
+      "extractionState" : "stale",
       "localizations" : {
         "zh-Hans" : {
           "stringUnit" : {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -1637,6 +1637,16 @@
         }
       }
     },
+    "Remember Last Popup Position" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "记住弹出窗口上次位置"
+          }
+        }
+      }
+    },
     "Request build failed" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -98,6 +98,37 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         migrateV1ProviderSettings()
         migrateV2KeychainToDefaults()
         migrateV3RemovedProviders()
+        migrateV4PopupPositionKeys()
+    }
+
+    /// V4: Earlier builds of the remember-position feature stored the panel's bottom-left
+    /// origin under `popupLastOriginX/Y`. We now persist the top-left corner under
+    /// `popupLastTopLeftX/Y` so the visual position survives size changes. Convert any
+    /// existing bottom-left value to top-left using the current default panel height as
+    /// the best available approximation, then clear the legacy keys. If the saved flag is
+    /// set but neither new nor old keys carry data, clear the flag so the panel falls back
+    /// to cursor/center instead of opening at (0,0).
+    private func migrateV4PopupPositionKeys() {
+        let migrationKey = "hasMigratedPopupPositionToTopLeft"
+        guard !UserDefaults.standard.bool(forKey: migrationKey) else { return }
+
+        let ud = UserDefaults.standard
+        let oldX = ud.object(forKey: "popupLastOriginX") as? Double
+        let oldY = ud.object(forKey: "popupLastOriginY") as? Double
+
+        if let oldX, let oldY {
+            let height = Double(Defaults[.popupDefaultHeight])
+            Defaults[.popupLastTopLeftX] = oldX
+            Defaults[.popupLastTopLeftY] = oldY + height
+            ud.removeObject(forKey: "popupLastOriginX")
+            ud.removeObject(forKey: "popupLastOriginY")
+        } else if Defaults[.popupHasSavedPosition],
+                  Defaults[.popupLastTopLeftX] == 0,
+                  Defaults[.popupLastTopLeftY] == 0 {
+            Defaults[.popupHasSavedPosition] = false
+        }
+
+        UserDefaults.standard.set(true, forKey: migrationKey)
     }
 
     /// V1: Migrate old flat keys to namespaced provider keys.

--- a/Sources/UI/PopupPanel/PopupPanel.swift
+++ b/Sources/UI/PopupPanel/PopupPanel.swift
@@ -1,5 +1,4 @@
 import AppKit
-import Defaults
 import SwiftUI
 
 // MARK: - Environment Key
@@ -26,6 +25,11 @@ final class PopupPanel: NSPanel {
     /// Set when `focusSourceInput()` is called before the source text view has been mounted.
     /// `SubmitAwareTextView.viewDidMoveToWindow` consumes this flag once the view attaches.
     private(set) var pendingSourceInputFocus = false
+
+    /// Number of upcoming `NSWindow.didMoveNotification` events that should be ignored by the
+    /// position-saving observer. The controller bumps this before each programmatic `setFrame`
+    /// so we don't overwrite the saved drag position with a freshly-computed show location.
+    var suppressNextMoveSave: Int = 0
 
     init(contentRect: NSRect) {
         super.init(
@@ -95,15 +99,8 @@ final class PopupPanel: NSPanel {
         if event.type == .leftMouseDown {
             if shouldStartWindowDrag(for: event) {
                 performDrag(with: event)
-                if Defaults[.popupRememberPosition] {
-                    // Persist the top-left corner: NSWindow.frame.origin is bottom-left in
-                    // screen coordinates, so the top-left y equals origin.y + height. Storing
-                    // top-left keeps the visual anchor stable across size changes between sessions.
-                    let f = frame
-                    Defaults[.popupLastTopLeftX] = Double(f.origin.x)
-                    Defaults[.popupLastTopLeftY] = Double(f.origin.y + f.height)
-                    Defaults[.popupHasSavedPosition] = true
-                }
+                // Position saving is handled by the controller's NSWindow.didMoveNotification
+                // observer, which fires during and at the end of the drag.
                 return
             }
             // Make panel key so text selection and other interactions work.

--- a/Sources/UI/PopupPanel/PopupPanel.swift
+++ b/Sources/UI/PopupPanel/PopupPanel.swift
@@ -96,9 +96,12 @@ final class PopupPanel: NSPanel {
             if shouldStartWindowDrag(for: event) {
                 performDrag(with: event)
                 if Defaults[.popupRememberPosition] {
-                    let origin = frame.origin
-                    Defaults[.popupLastOriginX] = Double(origin.x)
-                    Defaults[.popupLastOriginY] = Double(origin.y)
+                    // Persist the top-left corner: NSWindow.frame.origin is bottom-left in
+                    // screen coordinates, so the top-left y equals origin.y + height. Storing
+                    // top-left keeps the visual anchor stable across size changes between sessions.
+                    let f = frame
+                    Defaults[.popupLastTopLeftX] = Double(f.origin.x)
+                    Defaults[.popupLastTopLeftY] = Double(f.origin.y + f.height)
                     Defaults[.popupHasSavedPosition] = true
                 }
                 return

--- a/Sources/UI/PopupPanel/PopupPanel.swift
+++ b/Sources/UI/PopupPanel/PopupPanel.swift
@@ -95,6 +95,12 @@ final class PopupPanel: NSPanel {
         if event.type == .leftMouseDown {
             if shouldStartWindowDrag(for: event) {
                 performDrag(with: event)
+                if Defaults[.popupRememberPosition] {
+                    let origin = frame.origin
+                    Defaults[.popupLastOriginX] = Double(origin.x)
+                    Defaults[.popupLastOriginY] = Double(origin.y)
+                    Defaults[.popupHasSavedPosition] = true
+                }
                 return
             }
             // Make panel key so text selection and other interactions work.

--- a/Sources/UI/PopupPanel/PopupPanelController.swift
+++ b/Sources/UI/PopupPanel/PopupPanelController.swift
@@ -169,15 +169,41 @@ final class PopupPanelController {
         return true
     }
 
-    /// Returns the persisted last-dragged origin if the feature is enabled, a position has been saved,
-    /// and the panel rect at that origin intersects some screen's visible area. Otherwise returns nil
-    /// so the caller falls back to cursor/center positioning.
+    /// Returns the persisted last-dragged origin if the feature is enabled and a position has been
+    /// saved. The persisted point is the top-left corner, so we derive the NSWindow origin
+    /// (bottom-left) by subtracting the current panel height — this keeps the visual position
+    /// anchored even when the panel's width or height differs from the previously saved session.
+    /// The result is clamped to the visible frame of the screen containing the saved top-left so a
+    /// resized-larger panel doesn't spill off the edge.
     private func restoredOrigin(for size: CGSize) -> NSPoint? {
         guard Defaults[.popupRememberPosition], Defaults[.popupHasSavedPosition] else { return nil }
-        let origin = NSPoint(x: Defaults[.popupLastOriginX], y: Defaults[.popupLastOriginY])
+        let topLeft = NSPoint(
+            x: Defaults[.popupLastTopLeftX],
+            y: Defaults[.popupLastTopLeftY]
+        )
+        let origin = NSPoint(x: topLeft.x, y: topLeft.y - size.height)
         let candidate = NSRect(origin: origin, size: size)
-        guard NSScreen.screens.contains(where: { $0.visibleFrame.intersects(candidate) }) else { return nil }
-        return origin
+
+        // Prefer the screen that contained the saved top-left point; otherwise any screen the
+        // candidate rect still overlaps. If neither holds (e.g. external display disconnected),
+        // fall back to cursor/center logic.
+        guard let screen = NSScreen.screens.first(where: { $0.visibleFrame.contains(topLeft) })
+            ?? NSScreen.screens.first(where: { $0.visibleFrame.intersects(candidate) })
+        else { return nil }
+
+        return clampOrigin(origin, size: size, into: screen.visibleFrame)
+    }
+
+    private func clampOrigin(_ origin: NSPoint, size: CGSize, into bounds: NSRect) -> NSPoint {
+        let padding: CGFloat = 8
+        let minX = bounds.minX + padding
+        let maxX = bounds.maxX - size.width - padding
+        let minY = bounds.minY + padding
+        let maxY = bounds.maxY - size.height - padding
+        // If the screen is smaller than the panel along an axis, fall back to the min edge.
+        let clampedX = maxX >= minX ? min(max(origin.x, minX), maxX) : minX
+        let clampedY = maxY >= minY ? min(max(origin.y, minY), maxY) : minY
+        return NSPoint(x: clampedX, y: clampedY)
     }
 
     private func startDismissMonitor() {

--- a/Sources/UI/PopupPanel/PopupPanelController.swift
+++ b/Sources/UI/PopupPanel/PopupPanelController.swift
@@ -10,6 +10,7 @@ final class PopupPanelController {
     private var panel: PopupPanel?
     private var dismissMonitor: PopupDismissMonitor?
     private var copyShortcutDismissTask: Task<Void, Never>?
+    private var panelMoveObserver: NSObjectProtocol?
 
     private let coordinator: TranslationCoordinator
     private let ttsCoordinator: TTSCoordinator?
@@ -54,6 +55,7 @@ final class PopupPanelController {
                 screen: screen
             )
         }
+        panel.suppressNextMoveSave += 1
         panel.setFrame(frame, display: true)
         // Non-activating: don't steal focus from the user's active app.
         // The panel will accept key events (and ⌘1...⌘9 copy shortcuts) once the user clicks
@@ -82,6 +84,7 @@ final class PopupPanelController {
                 y: visibleFrame.midY - initialSize.height / 2
             )
         }
+        panel.suppressNextMoveSave += 1
         panel.setFrame(NSRect(origin: origin, size: initialSize), display: true)
         // Input mode needs the app activated so the panel can receive keyboard events.
         // Without this, makeKeyAndOrderFront alone won't route keystrokes to our panel
@@ -100,6 +103,10 @@ final class PopupPanelController {
         copyShortcutDismissTask = nil
         dismissMonitor?.stop()
         dismissMonitor = nil
+        if let observer = panelMoveObserver {
+            NotificationCenter.default.removeObserver(observer)
+            panelMoveObserver = nil
+        }
         ttsCoordinator?.stop()
         panel?.contentView = nil
         panel?.close()
@@ -152,9 +159,31 @@ final class PopupPanelController {
             hostingView.sizingOptions = []
             newPanel.contentView = hostingView
             panel = newPanel
+            panelMoveObserver = NotificationCenter.default.addObserver(
+                forName: NSWindow.didMoveNotification,
+                object: newPanel,
+                queue: .main
+            ) { [weak self, weak newPanel] _ in
+                guard let panel = newPanel else { return }
+                MainActor.assumeIsolated {
+                    self?.handlePanelMove(panel)
+                }
+            }
         }
 
         return initialSize
+    }
+
+    private func handlePanelMove(_ panel: PopupPanel) {
+        if panel.suppressNextMoveSave > 0 {
+            panel.suppressNextMoveSave -= 1
+            return
+        }
+        guard Defaults[.popupRememberPosition] else { return }
+        let f = panel.frame
+        Defaults[.popupLastTopLeftX] = Double(f.origin.x)
+        Defaults[.popupLastTopLeftY] = Double(f.origin.y + f.height)
+        Defaults[.popupHasSavedPosition] = true
     }
 
     private func copyResultFromShortcut(atDisplayIndex index: Int) -> Bool {

--- a/Sources/UI/PopupPanel/PopupPanelController.swift
+++ b/Sources/UI/PopupPanel/PopupPanelController.swift
@@ -29,6 +29,12 @@ final class PopupPanelController {
         self.settingsController = settingsController
     }
 
+    deinit {
+        if let observer = panelMoveObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+
     func showAtCursor() {
         let initialSize = setupPanel()
         guard let panel else { return }

--- a/Sources/UI/PopupPanel/PopupPanelController.swift
+++ b/Sources/UI/PopupPanel/PopupPanelController.swift
@@ -39,16 +39,21 @@ final class PopupPanelController {
             return
         }
 
-        let cursorPos = NSEvent.mouseLocation
-        guard let screen = NSScreen.screens.first(where: { $0.frame.contains(cursorPos) })
-            ?? NSScreen.main
-            ?? NSScreen.screens.first
-        else { return }
-        let frame = PopupPositioning.panelFrame(
-            contentSize: initialSize,
-            cursor: cursorPos,
-            screen: screen
-        )
+        let frame: NSRect
+        if let origin = restoredOrigin(for: initialSize) {
+            frame = NSRect(origin: origin, size: initialSize)
+        } else {
+            let cursorPos = NSEvent.mouseLocation
+            guard let screen = NSScreen.screens.first(where: { $0.frame.contains(cursorPos) })
+                ?? NSScreen.main
+                ?? NSScreen.screens.first
+            else { return }
+            frame = PopupPositioning.panelFrame(
+                contentSize: initialSize,
+                cursor: cursorPos,
+                screen: screen
+            )
+        }
         panel.setFrame(frame, display: true)
         // Non-activating: don't steal focus from the user's active app.
         // The panel will accept key events (and ⌘1...⌘9 copy shortcuts) once the user clicks
@@ -62,16 +67,21 @@ final class PopupPanelController {
         let initialSize = setupPanel()
         guard let panel else { return }
 
-        let cursorPos = NSEvent.mouseLocation
-        guard let screen = NSScreen.screens.first(where: { $0.frame.contains(cursorPos) })
-            ?? NSScreen.main
-            ?? NSScreen.screens.first
-        else { return }
-        let visibleFrame = screen.visibleFrame
-        let origin = NSPoint(
-            x: visibleFrame.midX - initialSize.width / 2,
-            y: visibleFrame.midY - initialSize.height / 2
-        )
+        let origin: NSPoint
+        if let saved = restoredOrigin(for: initialSize) {
+            origin = saved
+        } else {
+            let cursorPos = NSEvent.mouseLocation
+            guard let screen = NSScreen.screens.first(where: { $0.frame.contains(cursorPos) })
+                ?? NSScreen.main
+                ?? NSScreen.screens.first
+            else { return }
+            let visibleFrame = screen.visibleFrame
+            origin = NSPoint(
+                x: visibleFrame.midX - initialSize.width / 2,
+                y: visibleFrame.midY - initialSize.height / 2
+            )
+        }
         panel.setFrame(NSRect(origin: origin, size: initialSize), display: true)
         // Input mode needs the app activated so the panel can receive keyboard events.
         // Without this, makeKeyAndOrderFront alone won't route keystrokes to our panel
@@ -157,6 +167,17 @@ final class PopupPanelController {
             self?.dismiss()
         }
         return true
+    }
+
+    /// Returns the persisted last-dragged origin if the feature is enabled, a position has been saved,
+    /// and the panel rect at that origin intersects some screen's visible area. Otherwise returns nil
+    /// so the caller falls back to cursor/center positioning.
+    private func restoredOrigin(for size: CGSize) -> NSPoint? {
+        guard Defaults[.popupRememberPosition], Defaults[.popupHasSavedPosition] else { return nil }
+        let origin = NSPoint(x: Defaults[.popupLastOriginX], y: Defaults[.popupLastOriginY])
+        let candidate = NSRect(origin: origin, size: size)
+        guard NSScreen.screens.contains(where: { $0.visibleFrame.intersects(candidate) }) else { return nil }
+        return origin
     }
 
     private func startDismissMonitor() {

--- a/Sources/UI/Settings/GeneralSettingsView.swift
+++ b/Sources/UI/Settings/GeneralSettingsView.swift
@@ -12,6 +12,7 @@ struct GeneralSettingsView: View {
     @Default(.popupDefaultHeight) private var popupDefaultHeight
     @Default(.popupFontSize) private var popupFontSize
     @Default(.popupFontName) private var popupFontName
+    @Default(.popupRememberPosition) private var popupRememberPosition
     @Default(.sourceLanguage) private var sourceLanguage
     @Default(.detectionConfidenceThreshold) private var confidenceThreshold
     @Default(.appLanguage) private var appLanguage
@@ -119,6 +120,8 @@ struct GeneralSettingsView: View {
             }
 
             Section("Popup Panel") {
+                Toggle("Remember Last Popup Position", isOn: $popupRememberPosition)
+
                 LabeledContent("Default Width: \(popupDefaultWidth)") {
                     Slider(
                         value: Binding(

--- a/Sources/Utilities/Constants.swift
+++ b/Sources/Utilities/Constants.swift
@@ -103,11 +103,14 @@ extension Defaults.Keys {
     static let popupFontSize = Key<Int>("popupFontSize", default: 12)
     static let popupFontName = Key<String>("popupFontName", default: "")
 
-    // Popup panel last dragged position (used when popupRememberPosition is enabled)
+    // Popup panel last dragged position (used when popupRememberPosition is enabled).
+    // We persist the top-left corner so the visual position stays anchored even when the
+    // panel size differs between sessions (default size can change via Settings sliders or
+    // the in-panel resize grip).
     static let popupRememberPosition = Key<Bool>("popupRememberPosition", default: true)
     static let popupHasSavedPosition = Key<Bool>("popupHasSavedPosition", default: false)
-    static let popupLastOriginX = Key<Double>("popupLastOriginX", default: 0)
-    static let popupLastOriginY = Key<Double>("popupLastOriginY", default: 0)
+    static let popupLastTopLeftX = Key<Double>("popupLastTopLeftX", default: 0)
+    static let popupLastTopLeftY = Key<Double>("popupLastTopLeftY", default: 0)
 
     // Settings tab selection
     static let selectedSettingsTab = Key<SettingsTab>("selectedSettingsTab", default: .general)

--- a/Sources/Utilities/Constants.swift
+++ b/Sources/Utilities/Constants.swift
@@ -103,6 +103,12 @@ extension Defaults.Keys {
     static let popupFontSize = Key<Int>("popupFontSize", default: 12)
     static let popupFontName = Key<String>("popupFontName", default: "")
 
+    // Popup panel last dragged position (used when popupRememberPosition is enabled)
+    static let popupRememberPosition = Key<Bool>("popupRememberPosition", default: true)
+    static let popupHasSavedPosition = Key<Bool>("popupHasSavedPosition", default: false)
+    static let popupLastOriginX = Key<Double>("popupLastOriginX", default: 0)
+    static let popupLastOriginY = Key<Double>("popupLastOriginY", default: 0)
+
     // Settings tab selection
     static let selectedSettingsTab = Key<SettingsTab>("selectedSettingsTab", default: .general)
 


### PR DESCRIPTION
## Summary

Closes #61. Translation popup reopens at the last position the user dragged it to instead of jumping back near the cursor / screen-center each time.

- **Save**: observe `NSWindow.didMoveNotification` on the panel — fires reliably during and after each user drag. A `suppressNextMoveSave` counter on `PopupPanel` lets the controller skip saves caused by its own programmatic `setFrame` during show. (Earlier attempt of saving by reading `panel.frame` immediately after `performDrag(with:)` returned was flaky on some setups.)
- **Anchor**: persist the **top-left** corner (`popupLastTopLeftX/Y`) rather than NSWindow's bottom-left origin, so the visual position survives panel size changes between sessions (Settings sliders, in-panel resize grip).
- **Restore**: `PopupPanelController.restoredOrigin(for:)` derives the bottom-left origin from saved top-left + current panel height, prefers the screen that contained the saved top-left, then clamps to that screen's `visibleFrame` (8pt padding). Falls back to cursor / center when no screen overlaps (e.g. external display disconnected).
- **Settings**: new "Remember Last Popup Position" toggle in General → Popup Panel, default ON, zh-Hans localized.
- **Migration (V4)**: converts existing `popupLastOriginX/Y` (bottom-left) values to top-left using `popupDefaultHeight`, removes legacy keys; clears stale `popupHasSavedPosition` when no underlying data exists.
- **Memory hygiene**: observer token removed in both `dismiss()` and `deinit`.

## Test plan

- [ ] First launch, no saved data: ⌥D opens near cursor.
- [ ] Drag panel, dismiss, ⌥D again → reopens at dragged position.
- [ ] ⌥A (input mode) also uses the remembered position.
- [ ] Resize via grip → next reopen keeps the same top-left.
- [ ] Toggle off in Settings → cursor / center as before; toggle back on → remembered position.
- [ ] Disconnect external display whose position was saved → falls back to cursor.
- [ ] zh-Hans build shows "记住弹出窗口上次位置".
- [ ] Update from a build that had popupLastOriginX/Y set → first launch migrates without panel jumping into a corner.