### PR TITLE
feat: expand language codes to English names in prompts

### DIFF
--- a/Sources/Services/Providers/AnthropicProvider.swift
+++ b/Sources/Services/Providers/AnthropicProvider.swift
@@ -82,7 +82,10 @@ struct AnthropicProvider: ParallelModelProvider {
         }
 
         let promptTemplate = Defaults[systemPromptKey]
-        let systemPrompt = promptTemplate.replacingOccurrences(of: "{targetLang}", with: targetLang)
+        let systemPrompt = promptTemplate.replacingOccurrences(
+            of: "{targetLang}",
+            with: SupportedLanguages.englishName(for: targetLang)
+        )
         let maxTokens = Defaults[maxTokensKey]
 
         let body: [String: Any] = [

--- a/Sources/Services/Providers/LMStudioProvider.swift
+++ b/Sources/Services/Providers/LMStudioProvider.swift
@@ -58,7 +58,10 @@ struct LMStudioProvider: ParallelModelProvider {
                     }
 
                     let promptTemplate = Defaults[systemPromptKey]
-                    let systemPrompt = promptTemplate.replacingOccurrences(of: "{targetLang}", with: targetLang)
+                    let systemPrompt = promptTemplate.replacingOccurrences(
+                        of: "{targetLang}",
+                        with: SupportedLanguages.englishName(for: targetLang)
+                    )
 
                     let body: [String: Any] = [
                         "model": model,

--- a/Sources/Services/Providers/OllamaProvider.swift
+++ b/Sources/Services/Providers/OllamaProvider.swift
@@ -58,7 +58,10 @@ struct OllamaProvider: ParallelModelProvider {
                     }
 
                     let promptTemplate = Defaults[systemPromptKey]
-                    let systemPrompt = promptTemplate.replacingOccurrences(of: "{targetLang}", with: targetLang)
+                    let systemPrompt = promptTemplate.replacingOccurrences(
+                        of: "{targetLang}",
+                        with: SupportedLanguages.englishName(for: targetLang)
+                    )
 
                     let body: [String: Any] = [
                         "model": model,

--- a/Sources/Services/Providers/OpenAICompatibleProvider.swift
+++ b/Sources/Services/Providers/OpenAICompatibleProvider.swift
@@ -131,7 +131,10 @@ struct OpenAICompatibleProvider: ParallelModelProvider {
         }
 
         let promptTemplate = Defaults[systemPromptKey]
-        let systemPrompt = promptTemplate.replacingOccurrences(of: "{targetLang}", with: targetLang)
+        let systemPrompt = promptTemplate.replacingOccurrences(
+            of: "{targetLang}",
+            with: SupportedLanguages.englishName(for: targetLang)
+        )
 
         let body: [String: Any] = [
             "model": model,

--- a/Sources/Utilities/Constants.swift
+++ b/Sources/Utilities/Constants.swift
@@ -21,6 +21,35 @@ enum SupportedLanguages {
 
     /// Set of all supported language codes.
     static let codeSet: Set<String> = Set(codes)
+
+    /// English full names for language codes, used when interpolating into LLM prompts.
+    ///
+    /// Small models (≤2B params) often fail to recognize BCP-47 codes like `zh-Hans`,
+    /// so we expand to a stable English name. We hardcode the mapping rather than
+    /// using `Locale.localizedString(forIdentifier:)` to avoid locale-dependent
+    /// variations like "Chinese, Simplified" vs "Simplified Chinese".
+    private static let englishNames: [String: String] = [
+        "en": "English",
+        "zh-Hans": "Simplified Chinese",
+        "zh-Hant": "Traditional Chinese",
+        "ja": "Japanese",
+        "ko": "Korean",
+        "fr": "French",
+        "de": "German",
+        "es": "Spanish",
+        "pt-BR": "Brazilian Portuguese",
+        "ru": "Russian",
+        "ar": "Arabic",
+        "it": "Italian",
+        "th": "Thai",
+        "vi": "Vietnamese",
+    ]
+
+    /// Returns the English full name for a language code (e.g. `zh-Hans` → `Simplified Chinese`).
+    /// Falls back to the code itself for unknown identifiers.
+    static func englishName(for code: String) -> String {
+        englishNames[code] ?? code
+    }
 }
 
 // MARK: - App Language


### PR DESCRIPTION
## Summary

- Small LLMs (≤2B params) often fail to recognize BCP-47 codes like `zh-Hans`, `pt-BR`, etc., producing wrong-language output.
- Replace the `{targetLang}` placeholder in all four prompt-based providers (OpenAI-compatible, Anthropic, Ollama, LMStudio) with the full English name (e.g. `Simplified Chinese`, `Traditional Chinese`) at request time.
- Added `SupportedLanguages.englishName(for:)` helper with a hardcoded map for the 14 supported languages. Hardcoded instead of `Locale.localizedString(forIdentifier:)` to avoid locale-dependent variants like `"Chinese, Simplified"` vs `"Simplified Chinese"`.

The stored prompt template still contains the literal `{targetLang}` placeholder — only the runtime substitution changes. Existing user-customized prompts continue to work.

Closes #71

## Test plan

- [x] `tuist generate` + `xcodebuild ... build` succeeds
- [ ] Manually verify: with target language `zh-Hans` and a 2B local model (Ollama/LMStudio), translation produces Simplified Chinese output (not literal `zh-Hans` echo or wrong language)
- [ ] Verify each provider's `System Prompt` settings panel still shows the literal `{targetLang}` placeholder (template stored verbatim)
- [ ] Switch target to `zh-Hant` / `pt-BR` and confirm correct language output