### PR TITLE
feat(trigger-icon): add hover/click activation mode option

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -495,6 +495,16 @@
         }
       }
     },
+    "Click" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点击"
+          }
+        }
+      }
+    },
     "Click the refresh button above to fetch available models, or add a custom model below." : {
       "localizations" : {
         "zh-Hans" : {
@@ -837,6 +847,16 @@
         }
       }
     },
+    "Floating Icon Activation:" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "悬浮球触发方式："
+          }
+        }
+      }
+    },
     "Font Size: %lld" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -1005,6 +1025,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已授权"
+          }
+        }
+      }
+    },
+    "Hover" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "悬停"
           }
         }
       }

--- a/Sources/UI/Settings/GeneralSettingsView.swift
+++ b/Sources/UI/Settings/GeneralSettingsView.swift
@@ -9,6 +9,7 @@ struct GeneralSettingsView: View {
     @Default(.targetLanguage) private var targetLanguage
     @Default(.isAutoDetectEnabled) private var isAutoDetectEnabled
     @Default(.textDetectionMode) private var textDetectionMode
+    @Default(.triggerActivationMode) private var triggerActivationMode
     @Default(.showInDock) private var showInDock
     @Default(.popupDefaultWidth) private var popupDefaultWidth
     @Default(.popupDefaultHeight) private var popupDefaultHeight
@@ -122,6 +123,11 @@ struct GeneralSettingsView: View {
                 Toggle("Show floating icon on text selection", isOn: $isAutoDetectEnabled)
 
                 if isAutoDetectEnabled {
+                    Picker("Floating Icon Activation:", selection: $triggerActivationMode) {
+                        Text("Hover").tag(TriggerActivationMode.hover)
+                        Text("Click").tag(TriggerActivationMode.click)
+                    }
+
                     Picker("Text Detection Mode:", selection: $textDetectionMode) {
                         Text("Conservative").tag(TextDetectionMode.conservative)
                         Text("Standard").tag(TextDetectionMode.standard)

--- a/Sources/UI/TriggerIcon/TriggerIconController.swift
+++ b/Sources/UI/TriggerIcon/TriggerIconController.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Defaults
 
 // MARK: - TriggerTrackingView
 
@@ -104,11 +105,28 @@ final class TriggerIconController {
         let panel = TriggerIconPanel()
         let trackingView = TriggerTrackingView(frame: NSRect(x: 0, y: 0, width: TriggerIconPanel.size, height: TriggerIconPanel.size))
 
+        let activationMode = Defaults[.triggerActivationMode]
+
         trackingView.onMouseEntered = { [weak self] in
-            self?.startHoverTimer()
+            guard let self else { return }
+            switch activationMode {
+            case .hover:
+                self.startHoverTimer()
+            case .click:
+                // Pause auto-dismiss while cursor is over the icon so the user has time to click.
+                self.cancelAutoDismissTimer()
+            }
         }
         trackingView.onMouseExited = { [weak self] in
-            self?.cancelHoverTimer()
+            guard let self else { return }
+            switch activationMode {
+            case .hover:
+                self.cancelHoverTimer()
+            case .click:
+                // In click mode, mouseEntered paused auto-dismiss; restart it on exit
+                // so the icon eventually disappears if the user never clicks.
+                self.startAutoDismissTimer()
+            }
         }
         trackingView.onMouseDown = { [weak self] in
             self?.triggerTranslation()

--- a/Sources/Utilities/Constants.swift
+++ b/Sources/Utilities/Constants.swift
@@ -111,6 +111,13 @@ enum MenuBarIconCatalog {
     ]
 }
 
+// MARK: - Trigger Icon Activation Mode
+
+enum TriggerActivationMode: String, CaseIterable, Defaults.Serializable {
+    case hover  // Hover over the trigger icon (default behavior)
+    case click  // Click the trigger icon
+}
+
 // MARK: - Settings Tab
 
 enum SettingsTab: String, Defaults.Serializable {
@@ -152,6 +159,7 @@ extension Defaults.Keys {
     // Auto-detect text selection
     static let isAutoDetectEnabled = Key<Bool>("isAutoDetectEnabled", default: true)
     static let textDetectionMode = Key<TextDetectionMode>("textDetectionMode", default: .full)
+    static let triggerActivationMode = Key<TriggerActivationMode>("triggerActivationMode", default: .hover)
     static let excludedAppBundleIDs = Key<Set<String>>("excludedAppBundleIDs", default: [])
 
     // Appearance


### PR DESCRIPTION
## Summary

- Add `TriggerActivationMode` enum (`.hover` default / `.click`) + `Defaults.Keys.triggerActivationMode`.
- `TriggerIconController` reads mode at show time. Hover mode keeps the existing 0.3s hover-timer path; click mode skips it — `mouseEntered` pauses auto-dismiss while the cursor is over the icon, and `mouseExited` restarts the 3s auto-dismiss so the icon eventually disappears if the user never clicks. `mouseDown` always triggers translation.
- New `Floating Icon Activation:` Picker in General settings, exposed under the existing auto-detect toggle.
- Localized new strings (`Hover` / `Click` / `Floating Icon Activation:`) for en + zh-Hans.

Closes #58

## Test plan

- [ ] Default behavior unchanged: hover for 0.3s over the floating icon triggers translation.
- [ ] Switch `Floating Icon Activation` to `Click`: hovering does **not** trigger; clicking does.
- [ ] In click mode, idle hover over the icon pauses the 3s auto-dismiss timer; moving away restarts it.
- [ ] Setting persists across relaunch (verified via `Defaults`).
- [ ] zh-Hans locale shows `悬浮球触发方式：` / `悬停` / `点击`.