### PR TITLE
feat(menubar): customizable status bar icon

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -366,6 +366,17 @@
         }
       }
     },
+    "Cancel" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消"
+          }
+        }
+      }
+    },
     "Capability data from" : {
       "localizations" : {
         "zh-Hans" : {
@@ -441,12 +452,34 @@
         }
       }
     },
+    "Choose" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择"
+          }
+        }
+      }
+    },
     "Choose a provider from the list to configure it." : {
       "localizations" : {
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "从列表中选择一个翻译服务进行配置。"
+          }
+        }
+      }
+    },
+    "Choose Image…" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择图片…"
           }
         }
       }
@@ -572,8 +605,29 @@
     "Copyright © 2025-2026 MoePeek. All rights reserved." : {
 
     },
-    "Custom" : {
+    "Could not decode image." : {
       "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法解析该图片。"
+          }
+        }
+      }
+    },
+    "Could not load icon" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法加载图标"
+          }
+        }
+      }
+    },
+    "Custom" : {
       "localizations" : {
         "zh-Hans" : {
           "stringUnit" : {
@@ -741,6 +795,17 @@
         }
       }
     },
+    "Failed to save image: %@" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存图片失败：%@"
+          }
+        }
+      }
+    },
     "Fetch available models" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -748,6 +813,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "获取可用模型列表"
+          }
+        }
+      }
+    },
+    "Filled" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "面性"
           }
         }
       }
@@ -930,6 +1005,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已授权"
+          }
+        }
+      }
+    },
+    "Image file too large. Maximum 2 MB." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "图片文件过大，上限 2 MB。"
+          }
+        }
+      }
+    },
+    "Image:" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "图片："
           }
         }
       }
@@ -1137,6 +1234,17 @@
     "Max Tokens" : {
 
     },
+    "Menu Bar Icon" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "菜单栏图标"
+          }
+        }
+      }
+    },
     "Menu Bar Translation Tool" : {
       "localizations" : {
         "zh-Hans" : {
@@ -1201,6 +1309,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "更多翻译服务请前往设置中配置"
+          }
+        }
+      }
+    },
+    "Need inspiration? Browse free icons on [Iconify](https://icon-sets.iconify.design/?query=translate) — download an SVG or PNG and upload it here." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找灵感？在 [Iconify](https://icon-sets.iconify.design/?query=translate) 上浏览免费图标，下载 SVG 或 PNG 后上传到这里。"
           }
         }
       }
@@ -1369,6 +1487,17 @@
         }
       }
     },
+    "OK" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "好"
+          }
+        }
+      }
+    },
     "Ollama server not running at %@" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -1442,6 +1571,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "排序"
+          }
+        }
+      }
+    },
+    "Outline" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "线性"
           }
         }
       }
@@ -1552,6 +1692,38 @@
         }
       }
     },
+    "Presets" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "预设"
+          }
+        }
+      }
+    },
+    "Presets:" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "预设："
+          }
+        }
+      }
+    },
+    "Preview:" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "预览："
+          }
+        }
+      }
+    },
     "Previous" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -1648,6 +1820,39 @@
         }
       }
     },
+    "Remove" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除"
+          }
+        }
+      }
+    },
+    "Remove custom menu bar icon?" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除自定义菜单栏图标？"
+          }
+        }
+      }
+    },
+    "Render as template (monochrome)" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "渲染为模板（单色）"
+          }
+        }
+      }
+    },
     "Request build failed" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -1699,6 +1904,27 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "用于读取选中的文本"
+          }
+        }
+      }
+    },
+    "Requirements: PNG, JPG, SVG, PDF, TIFF, or ICNS, up to 2 MB. Recommended 36×36 px (18 pt @2x) with transparent background. For template mode, ship a monochrome image — black on transparent, alpha controls visibility." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要求：PNG、JPG、SVG、PDF、TIFF 或 ICNS，最大 2 MB。推荐 36×36 像素（18 pt @2x），背景透明。模板模式下请提供单色图（黑色 + 透明 alpha 控制可见性）。"
+          }
+        }
+      }
+    },
+    "Reset" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重置"
           }
         }
       }
@@ -1996,6 +2222,16 @@
         }
       }
     },
+    "SF Symbol" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SF Symbol"
+          }
+        }
+      }
+    },
     "Show Dock icon" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -2061,6 +2297,17 @@
         }
       }
     },
+    "Source:" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "来源："
+          }
+        }
+      }
+    },
     "Standard" : {
       "localizations" : {
         "zh-Hans" : {
@@ -2092,6 +2339,17 @@
         }
       }
     },
+    "Style:" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "样式："
+          }
+        }
+      }
+    },
     "Supports reasoning / chain-of-thought" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -2110,6 +2368,39 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "支持工具调用"
+          }
+        }
+      }
+    },
+    "Symbol exists on this system." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当前系统存在该图标。"
+          }
+        }
+      }
+    },
+    "Symbol name:" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "图标名称："
+          }
+        }
+      }
+    },
+    "Symbol not found. Falling back to default." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到该图标，将回退至默认值。"
           }
         }
       }
@@ -2168,6 +2459,16 @@
         }
       }
     },
+    "Template mode masks the image to the menu bar tint — recommended for monochrome icons so they adapt to light and dark menu bars. Turn it off only for full-color logos." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "模板模式会用菜单栏色调对图片进行蒙版渲染，建议单色图标使用以便适配明暗菜单栏。仅在需要保留彩色 Logo 时关闭。"
+          }
+        }
+      }
+    },
     "Test" : {
       "localizations" : {
         "zh-Hans" : {
@@ -2206,6 +2507,26 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "需要以下权限才能正常工作，\n接下来将引导你逐步完成设置。"
+          }
+        }
+      }
+    },
+    "The uploaded image will be deleted. You can choose another image any time." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已上传的图片会被删除，你可以随时重新选择一张。"
+          }
+        }
+      }
+    },
+    "Tip: open the SF Symbols app from Apple to browse all available names, then paste one above. Names are case-sensitive." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提示：可以打开 Apple 的 SF Symbols app 浏览所有可用名称，然后粘贴到上面。名称区分大小写。"
           }
         }
       }
@@ -2347,6 +2668,27 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "不支持"
+          }
+        }
+      }
+    },
+    "Unsupported image format. Use PNG, JPG, SVG, PDF, TIFF, or ICNS." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不支持的图片格式，请使用 PNG、JPG、SVG、PDF、TIFF 或 ICNS。"
+          }
+        }
+      }
+    },
+    "Upload" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上传"
           }
         }
       }

--- a/Sources/App/MoePeekApp.swift
+++ b/Sources/App/MoePeekApp.swift
@@ -1,13 +1,47 @@
+import AppKit
+import Defaults
 import SwiftUI
 
 @main
 struct MoePeekApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
 
+    @Default(.menuBarIconStyle) private var menuBarIconStyle
+    @Default(.menuBarCustomIconSource) private var customIconSource
+    @Default(.menuBarCustomSymbolName) private var customSymbolName
+    @Default(.menuBarCustomIconIsTemplate) private var customIconIsTemplate
+    @Default(.menuBarCustomIconRevision) private var customIconRevision
+
     var body: some Scene {
-        // Menu bar icon + dropdown
-        MenuBarExtra("MoePeek", systemImage: "character.bubble") {
+        MenuBarExtra {
             MenuItemView(appDelegate: appDelegate)
+        } label: {
+            menuBarLabel
+                // `.id` forces the label to rebuild when the user replaces the custom icon file.
+                .id(customIconRevision)
+        }
+    }
+
+    @ViewBuilder
+    private var menuBarLabel: some View {
+        switch menuBarIconStyle {
+        case .filled:
+            Image(systemName: MenuBarIconCatalog.defaultSymbol)
+        case .custom:
+            switch customIconSource {
+            case .symbol:
+                if NSImage(systemSymbolName: customSymbolName, accessibilityDescription: nil) != nil {
+                    Image(systemName: customSymbolName)
+                } else {
+                    Image(systemName: MenuBarIconCatalog.defaultSymbol)
+                }
+            case .image:
+                if let nsImage = MenuBarIconStore.loadCustomIcon(isTemplate: customIconIsTemplate) {
+                    Image(nsImage: nsImage)
+                } else {
+                    Image(systemName: MenuBarIconCatalog.defaultSymbol)
+                }
+            }
         }
     }
 }

--- a/Sources/Core/MenuBarIconStore.swift
+++ b/Sources/Core/MenuBarIconStore.swift
@@ -1,0 +1,116 @@
+import AppKit
+import Defaults
+import Foundation
+
+/// Manages on-disk storage for the user-supplied menu bar icon.
+///
+/// Files are stored under `Application Support/MoePeek/` with a fixed basename
+/// (`menuBarIcon.<ext>`) so we can locate the icon without persisting a path.
+@MainActor
+enum MenuBarIconStore {
+    static let supportedExtensions: Set<String> = ["png", "jpg", "jpeg", "svg", "pdf", "tiff", "icns"]
+
+    /// Recommended on-screen point size for a macOS menu bar icon.
+    static let recommendedPointSize: CGFloat = 18
+
+    /// Hard upper bound — anything larger is almost certainly wrong for a status item.
+    static let maxFileSize: Int = 2 * 1024 * 1024 // 2 MB
+
+    enum ImportError: LocalizedError {
+        case unsupportedFormat
+        case fileTooLarge
+        case invalidImage
+        case copyFailed(Error)
+
+        var errorDescription: String? {
+            switch self {
+            case .unsupportedFormat:
+                String(localized: "Unsupported image format. Use PNG, JPG, SVG, PDF, TIFF, or ICNS.")
+            case .fileTooLarge:
+                String(localized: "Image file too large. Maximum 2 MB.")
+            case .invalidImage:
+                String(localized: "Could not decode image.")
+            case .copyFailed(let error):
+                String(localized: "Failed to save image: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    /// Validate, copy into Application Support, bump the revision counter so observers refresh.
+    @discardableResult
+    static func importIcon(from sourceURL: URL) throws -> URL {
+        let ext = sourceURL.pathExtension.lowercased()
+        guard supportedExtensions.contains(ext) else {
+            throw ImportError.unsupportedFormat
+        }
+
+        let attrs = try FileManager.default.attributesOfItem(atPath: sourceURL.path)
+        if let size = attrs[.size] as? Int, size > maxFileSize {
+            throw ImportError.fileTooLarge
+        }
+
+        guard NSImage(contentsOf: sourceURL) != nil else {
+            throw ImportError.invalidImage
+        }
+
+        let directory = try ensureCustomIconDirectory()
+
+        // Wipe any pre-existing icon (possibly a different extension) so the lookup is unambiguous.
+        removeCustomIconFiles()
+
+        let destURL = directory.appendingPathComponent("menuBarIcon.\(ext)")
+        do {
+            try FileManager.default.copyItem(at: sourceURL, to: destURL)
+        } catch {
+            throw ImportError.copyFailed(error)
+        }
+
+        Defaults[.menuBarCustomIconRevision] += 1
+        return destURL
+    }
+
+    static func removeCustomIcon() {
+        removeCustomIconFiles()
+        Defaults[.menuBarCustomIconRevision] += 1
+    }
+
+    /// Loads the custom icon sized for the menu bar, applying the template flag.
+    /// Returns nil when no custom icon is present.
+    static func loadCustomIcon(isTemplate: Bool) -> NSImage? {
+        guard let url = currentCustomIconURL, let image = NSImage(contentsOf: url) else {
+            return nil
+        }
+        image.size = NSSize(width: recommendedPointSize, height: recommendedPointSize)
+        image.isTemplate = isTemplate
+        return image
+    }
+
+    // MARK: - Private
+
+    private static var customIconDirectory: URL {
+        let supportDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        return supportDir.appendingPathComponent("MoePeek", isDirectory: true)
+    }
+
+    private static func ensureCustomIconDirectory() throws -> URL {
+        let directory = customIconDirectory
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    private static var currentCustomIconURL: URL? {
+        let directory = customIconDirectory
+        for ext in supportedExtensions {
+            let url = directory.appendingPathComponent("menuBarIcon.\(ext)")
+            if FileManager.default.fileExists(atPath: url.path) { return url }
+        }
+        return nil
+    }
+
+    private static func removeCustomIconFiles() {
+        let directory = customIconDirectory
+        for ext in supportedExtensions {
+            try? FileManager.default.removeItem(at: directory.appendingPathComponent("menuBarIcon.\(ext)"))
+        }
+    }
+}

--- a/Sources/UI/Settings/GeneralSettingsView.swift
+++ b/Sources/UI/Settings/GeneralSettingsView.swift
@@ -1,7 +1,9 @@
+import AppKit
 import Defaults
 import KeyboardShortcuts
 import ServiceManagement
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct GeneralSettingsView: View {
     @Default(.targetLanguage) private var targetLanguage
@@ -16,6 +18,14 @@ struct GeneralSettingsView: View {
     @Default(.sourceLanguage) private var sourceLanguage
     @Default(.detectionConfidenceThreshold) private var confidenceThreshold
     @Default(.appLanguage) private var appLanguage
+    @Default(.menuBarIconStyle) private var menuBarIconStyle
+    @Default(.menuBarCustomIconSource) private var menuBarCustomIconSource
+    @Default(.menuBarCustomSymbolName) private var menuBarCustomSymbolName
+    @Default(.menuBarCustomIconIsTemplate) private var menuBarCustomIconIsTemplate
+    @Default(.menuBarCustomIconRevision) private var menuBarCustomIconRevision
+
+    @State private var iconImportError: String?
+    @State private var showingIconResetConfirm = false
 
     private var textDetectionModeDescription: String {
         switch textDetectionMode {
@@ -77,6 +87,29 @@ struct GeneralSettingsView: View {
                             NSApp.activate()
                         }
                     }
+            }
+
+            Section("Menu Bar Icon") {
+                Picker("Style:", selection: $menuBarIconStyle) {
+                    Text("Filled").tag(MenuBarIconStyle.filled)
+                    Text("Custom").tag(MenuBarIconStyle.custom)
+                }
+                .pickerStyle(.segmented)
+
+                if menuBarIconStyle == .custom {
+                    Picker("Source:", selection: $menuBarCustomIconSource) {
+                        Text("SF Symbol").tag(MenuBarCustomIconSource.symbol)
+                        Text("Upload").tag(MenuBarCustomIconSource.image)
+                    }
+                    .pickerStyle(.segmented)
+
+                    switch menuBarCustomIconSource {
+                    case .symbol:
+                        menuBarSymbolControls
+                    case .image:
+                        menuBarCustomIconControls
+                    }
+                }
             }
 
             Section("Translation") {
@@ -174,6 +207,173 @@ struct GeneralSettingsView: View {
             Button("Later", role: .cancel) { }
         } message: {
             Text("Changing language requires restarting the app.")
+        }
+        .alert(
+            "Could not load icon",
+            isPresented: Binding(
+                get: { iconImportError != nil },
+                set: { if !$0 { iconImportError = nil } }
+            ),
+            actions: { Button("OK", role: .cancel) { iconImportError = nil } },
+            message: { Text(iconImportError ?? "") }
+        )
+        .confirmationDialog(
+            "Remove custom menu bar icon?",
+            isPresented: $showingIconResetConfirm,
+            titleVisibility: .visible
+        ) {
+            Button("Remove", role: .destructive) {
+                MenuBarIconStore.removeCustomIcon()
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("The uploaded image will be deleted. You can choose another image any time.")
+        }
+    }
+
+    @ViewBuilder
+    private var menuBarSymbolControls: some View {
+        let isValid = isValidSymbol(menuBarCustomSymbolName)
+        let previewName = isValid ? menuBarCustomSymbolName : MenuBarIconCatalog.defaultSymbol
+
+        // Preview + free-form name input in a single row so the user sees them together.
+        HStack(spacing: 10) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(Color.secondary.opacity(0.12))
+                Image(systemName: previewName)
+                    .font(.system(size: 16))
+            }
+            .frame(width: 32, height: 32)
+
+            TextField(
+                text: $menuBarCustomSymbolName,
+                prompt: Text(verbatim: MenuBarIconCatalog.defaultSymbol)
+            ) {
+                EmptyView()
+            }
+            .textFieldStyle(.roundedBorder)
+            .autocorrectionDisabled()
+            .frame(maxWidth: .infinity)
+
+            Image(systemName: isValid ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+                .foregroundStyle(isValid ? .green : .orange)
+                .help(isValid
+                    ? String(localized: "Symbol exists on this system.")
+                    : String(localized: "Symbol not found. Falling back to default."))
+        }
+
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Presets")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            LazyVGrid(
+                columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: 6),
+                spacing: 8
+            ) {
+                ForEach(MenuBarIconCatalog.presets, id: \.self) { name in
+                    Button {
+                        menuBarCustomSymbolName = name
+                    } label: {
+                        Image(systemName: name)
+                            .font(.system(size: 15))
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 32)
+                            .background(
+                                RoundedRectangle(cornerRadius: 6)
+                                    .fill(menuBarCustomSymbolName == name
+                                        ? Color.accentColor.opacity(0.25)
+                                        : Color.secondary.opacity(0.10))
+                            )
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 6)
+                                    .strokeBorder(
+                                        menuBarCustomSymbolName == name
+                                            ? Color.accentColor
+                                            : Color.clear,
+                                        lineWidth: 1.5
+                                    )
+                            )
+                    }
+                    .buttonStyle(.plain)
+                    .help(name)
+                    .accessibilityLabel(Text(verbatim: name))
+                }
+            }
+        }
+
+        Text("Tip: open the SF Symbols app from Apple to browse all available names, then paste one above. Names are case-sensitive.")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+    }
+
+    private func isValidSymbol(_ name: String) -> Bool {
+        guard !name.isEmpty else { return false }
+        return NSImage(systemSymbolName: name, accessibilityDescription: nil) != nil
+    }
+
+    @ViewBuilder
+    private var menuBarCustomIconControls: some View {
+        let customIcon = MenuBarIconStore.loadCustomIcon(isTemplate: menuBarCustomIconIsTemplate)
+        let hasCustomIcon = customIcon != nil
+
+        LabeledContent("Image:") {
+            HStack(spacing: 12) {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(Color.secondary.opacity(0.12))
+                    if let customIcon {
+                        Image(nsImage: customIcon)
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 22, height: 22)
+                    } else {
+                        Image(systemName: "photo")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .frame(width: 36, height: 36)
+
+                Button("Choose Image…") { chooseCustomIcon() }
+                if hasCustomIcon {
+                    Button("Reset", role: .destructive) {
+                        showingIconResetConfirm = true
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+        }
+
+        Toggle("Render as template (monochrome)", isOn: $menuBarCustomIconIsTemplate)
+
+        Text("Template mode masks the image to the menu bar tint — recommended for monochrome icons so they adapt to light and dark menu bars. Turn it off only for full-color logos.")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+        Text("Requirements: PNG, JPG, SVG, PDF, TIFF, or ICNS, up to 2 MB. Recommended 36×36 px (18 pt @2x) with transparent background. For template mode, ship a monochrome image — black on transparent, alpha controls visibility.")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+        Text("Need inspiration? Browse free icons on [Iconify](https://icon-sets.iconify.design/?query=translate) — download an SVG or PNG and upload it here.")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .tint(.accentColor)
+    }
+
+    private func chooseCustomIcon() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        panel.allowedContentTypes = [
+            .png, .jpeg, .svg, .pdf, .tiff, .icns, UTType.image,
+        ]
+        panel.prompt = String(localized: "Choose")
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        do {
+            try MenuBarIconStore.importIcon(from: url)
+        } catch {
+            iconImportError = error.localizedDescription
         }
     }
 }

--- a/Sources/UI/Settings/SettingsView.swift
+++ b/Sources/UI/Settings/SettingsView.swift
@@ -11,7 +11,7 @@ struct SettingsView: View {
 
     private var tabHeight: CGFloat {
         switch selectedTab {
-        case .general: return 680
+        case .general: return 840
         case .excludedApps: return 480
         case .services: return 580
         case .providerOrder: return 520

--- a/Sources/Utilities/Constants.swift
+++ b/Sources/Utilities/Constants.swift
@@ -47,6 +47,41 @@ enum TextDetectionMode: String, CaseIterable, Defaults.Serializable {
     case full          // Tier 1 + Tier 2 + Tier 3 (AX + AppleScript + ⌘C simulation)
 }
 
+// MARK: - Menu Bar Icon Style
+
+enum MenuBarIconStyle: String, CaseIterable, Defaults.Serializable {
+    case filled
+    case custom
+}
+
+enum MenuBarCustomIconSource: String, CaseIterable, Defaults.Serializable {
+    case symbol
+    case image
+}
+
+/// Constants describing the SF Symbols catalog used by the menu bar icon UI.
+enum MenuBarIconCatalog {
+    /// Default SF Symbol surfaced when the user first picks a custom symbol icon.
+    /// Kept in sync with the `filled` style so switching to custom is non-disruptive.
+    static let defaultSymbol = "character.bubble.fill"
+
+    /// Curated SF Symbol presets exposed in Settings. Names must exist on macOS 14.
+    static let presets: [String] = [
+        "character.bubble.fill",
+        "text.bubble.fill",
+        "bubble.left.fill",
+        "globe",
+        "globe.americas.fill",
+        "character.book.closed.fill",
+        "text.viewfinder",
+        "sparkles",
+        "abc",
+        "textformat",
+        "character",
+        "command",
+    ]
+}
+
 // MARK: - Settings Tab
 
 enum SettingsTab: String, Defaults.Serializable {
@@ -92,6 +127,14 @@ extension Defaults.Keys {
 
     // Appearance
     static let showInDock = Key<Bool>("showInDock", default: true)
+
+    // Menu bar icon
+    static let menuBarIconStyle = Key<MenuBarIconStyle>("menuBarIconStyle", default: .filled)
+    static let menuBarCustomIconSource = Key<MenuBarCustomIconSource>("menuBarCustomIconSource", default: .symbol)
+    static let menuBarCustomSymbolName = Key<String>("menuBarCustomSymbolName", default: MenuBarIconCatalog.defaultSymbol)
+    static let menuBarCustomIconIsTemplate = Key<Bool>("menuBarCustomIconIsTemplate", default: true)
+    // Bumped whenever the custom icon file is replaced so SwiftUI re-evaluates the cached image.
+    static let menuBarCustomIconRevision = Key<Int>("menuBarCustomIconRevision", default: 0)
 
     // Onboarding
     static let hasCompletedOnboarding = Key<Bool>("hasCompletedOnboarding", default: false)


### PR DESCRIPTION
## Summary

- Default menu bar icon switched from outline `character.bubble` to filled `character.bubble.fill`.
- New **Settings → General → Menu Bar Icon** section lets users choose a custom icon with two sources:
  - **SF Symbol**: 12 curated presets in a 6-column grid + free-form name input with live preview and a green/orange validation indicator. Invalid names fall back to the default.
  - **Upload**: PNG / JPG / SVG / PDF / TIFF / ICNS (≤ 2 MB) copied to `Application Support/MoePeek/`. Template-mode toggle for light/dark adaptation. Confirmation dialog before reset. In-pane link to [Iconify](https://icon-sets.iconify.design/?query=translate) for free icon discovery.
- Adds `MenuBarIconStore` (on-disk file IO with format / size / decode validation) and `MenuBarIconCatalog` (curated SF Symbol presets).
- Four new Defaults keys: `menuBarIconStyle`, `menuBarCustomIconSource`, `menuBarCustomSymbolName`, `menuBarCustomIconIsTemplate` (+ `menuBarCustomIconRevision` for cache invalidation).
- Full English + Simplified Chinese localizations.

Closes #57

## Screenshots

_TODO before merge: capture Settings → Menu Bar Icon panel in both SF Symbol and Upload modes._

## Test plan

- [ ] Fresh install: menu bar shows filled icon by default.
- [ ] Settings → Menu Bar Icon → switch to **Custom** → **SF Symbol**: clicking a preset updates the menu bar icon instantly; the selected preset shows the accent-color highlight.
- [ ] Paste a valid SF Symbol name (e.g. `pencil.tip`) into the text field: green ✓ + menu bar updates.
- [ ] Paste an invalid name (e.g. `foo.bar`): orange ⚠️ + menu bar falls back to default.
- [ ] Clear the text field: prompt shows `character.bubble.fill`, validation shows ⚠️, menu bar uses default.
- [ ] Switch source to **Upload** → choose a 36×36 monochrome PNG with transparent background. Verify preview, template mode toggle adapts to light/dark menu bar.
- [ ] Upload a > 2 MB file → import error alert appears.
- [ ] Upload an unsupported format (e.g. `.gif` renamed to `.png` with corrupt content) → decode error alert.
- [ ] Click **Reset** in Upload mode → confirmation dialog shown; clicking Remove deletes the file and falls back to default.
- [ ] Click the Iconify link → opens in default browser.
- [ ] Toggle App Language to 简体中文 + restart → all new strings translated.
- [ ] Restart the app → selected style / source / symbol / uploaded image persist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)