### PR TITLE
feat(popup): add configurable shortcut to swap source/target languages

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -1,6 +1,17 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    " · %@ Swap" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " · %@ 互换语言"
+          }
+        }
+      }
+    },
     "(default)" : {
       "localizations" : {
         "zh-Hans" : {
@@ -58,6 +69,7 @@
       }
     },
     "↵ Translate · ⌘↵ Copy & Close · ⇧↵ Newline" : {
+      "extractionState" : "stale",
       "localizations" : {
         "zh-Hans" : {
           "stringUnit" : {
@@ -848,6 +860,7 @@
       }
     },
     "Floating Icon Activation:" : {
+      "extractionState" : "stale",
       "localizations" : {
         "zh-Hans" : {
           "stringUnit" : {
@@ -2398,6 +2411,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "支持工具调用"
+          }
+        }
+      }
+    },
+    "Swap Languages:" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "互换语言："
           }
         }
       }

--- a/Sources/UI/PopupPanel/PopupView.swift
+++ b/Sources/UI/PopupPanel/PopupView.swift
@@ -146,6 +146,9 @@ struct PopupView: View {
                     onCopyAndClose: {
                         copySourceAndClose()
                     },
+                    onSwapLanguages: {
+                        swapLanguages()
+                    },
                     onContentHeightChange: { preferredHeight in
                         expandInputHeightIfNeeded(for: preferredHeight)
                     }
@@ -171,14 +174,7 @@ struct PopupView: View {
                         detectionConfidence: coordinator.detectionResult?.confidence,
                         targetLanguage: $targetLang,
                         onSwap: {
-                            let effectiveSource = sourceLang == "auto"
-                            ? (coordinator.detectedLanguage ?? targetLang)
-                            : sourceLang
-                            // When auto-detect has no result yet, effectiveSource falls back
-                            // to targetLang and swap becomes a no-op
-                            guard effectiveSource != targetLang else { return }
-                            sourceLang = targetLang
-                            targetLang = effectiveSource
+                            swapLanguages()
                         }
                     )
 
@@ -274,6 +270,17 @@ struct PopupView: View {
         let targetHeight = min(max(preferredHeight, baseline), maxInputHeight)
         guard abs(targetHeight - inputHeight) > 0.5 else { return }
         inputHeight = targetHeight
+    }
+
+    private func swapLanguages() {
+        let effectiveSource = sourceLang == "auto"
+        ? (coordinator.detectedLanguage ?? targetLang)
+        : sourceLang
+        // When auto-detect has no result yet, effectiveSource falls back
+        // to targetLang and swap becomes a no-op
+        guard effectiveSource != targetLang else { return }
+        sourceLang = targetLang
+        targetLang = effectiveSource
     }
 
     private func copySourceAndClose() {

--- a/Sources/UI/PopupPanel/SourceInputView.swift
+++ b/Sources/UI/PopupPanel/SourceInputView.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Defaults
+import KeyboardShortcuts
 import SwiftUI
 
 /// Editable source text input with Enter to translate, Shift+Enter for newline.
@@ -8,11 +9,15 @@ struct SourceInputView: View {
     let sourceLanguage: String
     let onSubmit: () -> Void
     let onCopyAndClose: () -> Void
+    let onSwapLanguages: () -> Void
     var onContentHeightChange: ((CGFloat) -> Void)?
     @Default(.popupFontSize) private var fontSize
     @Default(.popupFontName) private var fontName
     @Default(.ttsAccent) private var ttsAccent
     @Environment(\.ttsCoordinator) private var ttsCoordinator
+    // Keyboard shortcuts only reach the panel when it is the key window (e.g. selection
+    // translation shows the panel without focus); dim the hints when they wouldn't work.
+    @State private var isWindowKey = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -22,6 +27,10 @@ struct SourceInputView: View {
                 fontName: fontName,
                 onSubmit: onSubmit,
                 onCopyAndClose: onCopyAndClose,
+                onSwapLanguages: onSwapLanguages,
+                onWindowKeyChange: { isKey in
+                    isWindowKey = isKey
+                },
                 onContentHeightChange: { editorHeight in
                     onContentHeightChange?(sourceInputHeight(forEditorHeight: editorHeight))
                 }
@@ -57,11 +66,20 @@ struct SourceInputView: View {
 
                 Spacer()
 
-                Text("↵ Translate · ⌘↵ Copy & Close · ⇧↵ Newline")
+                Text(shortcutHint)
                     .font(.popup(name: fontName, size: CGFloat(fontSize - 4)))
                     .foregroundStyle(.quaternary)
+                    .opacity(isWindowKey ? 1 : 0.4)
             }
         }
+    }
+
+    /// The swap shortcut is user-configurable, so the hint shows whatever is currently
+    /// bound and drops that segment entirely once the user clears the binding.
+    private var shortcutHint: String {
+        let base = String(localized: "↵ Translate · ⌘↵ Copy & Close · ⇧↵ Newline")
+        guard let swap = KeyboardShortcuts.getShortcut(for: .swapLanguages) else { return base }
+        return base + String(localized: " · \(swap.description) Swap")
     }
 
     private func sourceInputHeight(forEditorHeight editorHeight: CGFloat) -> CGFloat {
@@ -77,6 +95,8 @@ private struct SourceTextEditor: NSViewRepresentable {
     let fontName: String
     let onSubmit: () -> Void
     let onCopyAndClose: () -> Void
+    let onSwapLanguages: () -> Void
+    let onWindowKeyChange: (Bool) -> Void
     let onContentHeightChange: (CGFloat) -> Void
 
     private var resolvedFont: NSFont {
@@ -121,6 +141,8 @@ private struct SourceTextEditor: NSViewRepresentable {
         textView.textContainerInset = .zero
         textView.onSubmit = onSubmit
         textView.onCopyAndClose = onCopyAndClose
+        textView.onSwapLanguages = onSwapLanguages
+        textView.onWindowKeyChange = onWindowKeyChange
         textView.textContainer?.containerSize = NSSize(
             width: contentSize.width,
             height: CGFloat.greatestFiniteMagnitude
@@ -158,6 +180,8 @@ private struct SourceTextEditor: NSViewRepresentable {
 
         textView.onSubmit = onSubmit
         textView.onCopyAndClose = onCopyAndClose
+        textView.onSwapLanguages = onSwapLanguages
+        textView.onWindowKeyChange = onWindowKeyChange
 
         coordinator.reportContentHeight()
     }
@@ -196,6 +220,8 @@ private struct SourceTextEditor: NSViewRepresentable {
 private final class SubmitAwareTextView: NSTextView {
     var onSubmit: (() -> Void)?
     var onCopyAndClose: (() -> Void)?
+    var onSwapLanguages: (() -> Void)?
+    var onWindowKeyChange: ((Bool) -> Void)?
     private var displayFont: NSFont = .systemFont(ofSize: NSFont.systemFontSize)
 
     func applyDisplayAttributes(font: NSFont) {
@@ -240,10 +266,43 @@ private final class SubmitAwareTextView: NSTextView {
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
+        observeWindowKeyStatus()
         // Event-driven first responder handoff: when SwiftUI mounts this text view into
         // the panel, consume the panel's one-shot focus request set by `focusSourceInput()`.
         guard let panel = window as? PopupPanel else { return }
         panel.consumePendingSourceInputFocus(into: self)
+    }
+
+    /// Tracks whether the hosting panel is the key window, so SwiftUI can dim the
+    /// shortcut hints when keystrokes would go to another app instead.
+    private func observeWindowKeyStatus() {
+        let center = NotificationCenter.default
+        center.removeObserver(self, name: NSWindow.didBecomeKeyNotification, object: nil)
+        center.removeObserver(self, name: NSWindow.didResignKeyNotification, object: nil)
+        guard let window else {
+            onWindowKeyChange?(false)
+            return
+        }
+        center.addObserver(
+            self,
+            selector: #selector(reportWindowKeyStatus),
+            name: NSWindow.didBecomeKeyNotification,
+            object: window
+        )
+        center.addObserver(
+            self,
+            selector: #selector(reportWindowKeyStatus),
+            name: NSWindow.didResignKeyNotification,
+            object: window
+        )
+        // Async so the initial report doesn't mutate SwiftUI state mid view update
+        Task { @MainActor [weak self] in
+            self?.reportWindowKeyStatus()
+        }
+    }
+
+    @objc private func reportWindowKeyStatus() {
+        onWindowKeyChange?(window?.isKeyWindow ?? false)
     }
 
     override func keyDown(with event: NSEvent) {
@@ -262,6 +321,15 @@ private final class SubmitAwareTextView: NSTextView {
         if isReturnKey, !hasCommand, !hasShift, !hasMarkedText() {
             guard !string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
             onSubmit?()
+            return
+        }
+
+        // User-configurable shortcut that swaps source/target languages
+        // (mirrors the swap button in LanguageBarView).
+        if !hasMarkedText(),
+           let configured = KeyboardShortcuts.getShortcut(for: .swapLanguages),
+           KeyboardShortcuts.Shortcut(event: event) == configured {
+            onSwapLanguages?()
             return
         }
 

--- a/Sources/UI/Settings/GeneralSettingsView.swift
+++ b/Sources/UI/Settings/GeneralSettingsView.swift
@@ -50,6 +50,8 @@ struct GeneralSettingsView: View {
                 KeyboardShortcuts.Recorder("Screenshot OCR:", name: .ocrScreenshot)
                 KeyboardShortcuts.Recorder("Manual Translation:", name: .inputTranslation)
                 KeyboardShortcuts.Recorder("Clipboard Translation:", name: .clipboardTranslation)
+
+                KeyboardShortcuts.Recorder("Swap Languages:", name: .swapLanguages)
             }
 
             Section("General") {

--- a/Sources/Utilities/Constants.swift
+++ b/Sources/Utilities/Constants.swift
@@ -136,6 +136,7 @@ extension KeyboardShortcuts.Name {
     static let ocrScreenshot = Self("ocrScreenshot", default: .init(.s, modifiers: .option))
     static let inputTranslation = Self("inputTranslation", default: .init(.a, modifiers: .option))
     static let clipboardTranslation = Self("clipboardTranslation", default: .init(.v, modifiers: .option))
+    static let swapLanguages = Self("swapLanguages", default: .init(.t, modifiers: .option))
 }
 
 // MARK: - User Defaults Keys


### PR DESCRIPTION
## Summary

Add an ⌥T shortcut (rebindable in Settings > Keyboard Shortcuts) that swaps source/target languages in the popup's source input, mirroring the swap button in LanguageBarView.

Since keyboard shortcuts only reach the popup when it is the key window (selection/OCR popups show without stealing focus), the hint bar now dims while the popup is not key, and renders whatever shortcut is currently bound.

## Screenshots

**Settings > General > Keyboard Shortcuts** — new "Swap Languages" recorder,
bound to ⌥T by default and rebindable/clearable like the existing shortcuts.
<img width="1440" height="1756" alt="image" src="https://github.com/user-attachments/assets/fe1b674a-4e68-4ab1-b181-a42320084d49" />

**Popup hint bar** — reflects the currently bound shortcut (⌥T 互换语言) next
to the existing Translate / Copy & Close / Newline hints, dims when unfocused and brightens when focused.
<img width="900" height="700" alt="image" src="https://github.com/user-attachments/assets/ffacfe1b-d293-4f15-83b0-228935e871f5" />
<img width="900" height="700" alt="image" src="https://github.com/user-attachments/assets/693d3a21-cab9-40c3-8f3e-39e742205275" />

## Test plan

- [x] ⌥T swaps source/target language while the popup has keyboard focus
- [x] Rebinding the shortcut in Settings updates the hint bar text immediately
- [x] Clearing the binding removes the swap segment from the hint bar
- [x] Shortcut hint dims when the popup is shown without stealing focus (selection/OCR)