### PR TITLE
fix(providers): show full connection test error message

### DIFF
--- a/Sources/Services/Providers/AnthropicSettingsView.swift
+++ b/Sources/Services/Providers/AnthropicSettingsView.swift
@@ -197,7 +197,8 @@ struct AnthropicSettingsView: View {
                         Label(message, systemImage: "xmark.circle.fill")
                             .foregroundStyle(.red)
                             .font(.caption)
-                            .lineLimit(2)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .textSelection(.enabled)
                     }
                 }
             }

--- a/Sources/Services/Providers/LocalLLMSettingsView.swift
+++ b/Sources/Services/Providers/LocalLLMSettingsView.swift
@@ -186,7 +186,8 @@ struct LocalLLMSettingsView: View {
                         Label(message, systemImage: "xmark.circle.fill")
                             .foregroundStyle(.red)
                             .font(.caption)
-                            .lineLimit(2)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .textSelection(.enabled)
                     }
                 }
             }

--- a/Sources/Services/Providers/OpenAIConnectionManager.swift
+++ b/Sources/Services/Providers/OpenAIConnectionManager.swift
@@ -109,9 +109,13 @@ final class OpenAIConnectionManager {
                 return
             }
             guard httpResponse.statusCode == 200 else {
-                let bodyText = String(data: data, encoding: .utf8) ?? ""
-                let preview = String(bodyText.prefix(200))
-                testResult = .failure(message: "HTTP \(httpResponse.statusCode): \(preview)")
+                if let decoded = try? JSONDecoder().decode(OpenAIErrorResponse.self, from: data) {
+                    testResult = .failure(message: "HTTP \(httpResponse.statusCode): \(decoded.error.message)")
+                } else {
+                    let bodyText = String(data: data, encoding: .utf8) ?? ""
+                    let preview = String(bodyText.prefix(200))
+                    testResult = .failure(message: "HTTP \(httpResponse.statusCode): \(preview)")
+                }
                 return
             }
             testResult = .success(latencyMs: ms)
@@ -133,6 +137,15 @@ final class OpenAIConnectionManager {
         guard trimmed.hasPrefix("http://") || trimmed.hasPrefix("https://"),
               !apiKey.isEmpty else { return nil }
         return URL(string: "\(trimmed)\(path)")
+    }
+}
+
+// MARK: - Error Response
+
+private struct OpenAIErrorResponse: Decodable {
+    let error: ErrorBody
+    struct ErrorBody: Decodable {
+        let message: String
     }
 }
 

--- a/Sources/Services/Providers/OpenAIConnectionViews.swift
+++ b/Sources/Services/Providers/OpenAIConnectionViews.swift
@@ -77,7 +77,8 @@ struct ConnectionTestView: View {
                     Label(message, systemImage: "xmark.circle.fill")
                         .foregroundStyle(.red)
                         .font(.caption)
-                        .lineLimit(2)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .textSelection(.enabled)
                 }
             }
         }


### PR DESCRIPTION
## Summary
Improve the error message when testing provider connections by showing a clear API error message instead of a truncated JSON response. Changes: Parse the API error response, display the actual message with preserved line breaks, and remove the two-line truncation so long messages are fully visible. Before: Only the HTTP status code and truncated JSON were shown, making the real error hard to read. After: The actual error message is shown readable and complete, making configuration issues easier to diagnose. Testing: Verified locally with invalid provider configurations, confirming messages display correctly.

## Screenshots
### Before
<img width="1598" height="926" alt="image" src="https://github.com/user-attachments/assets/17a7d0ef-bb9d-4b0e-ba10-002091bb7110" />

### After 
<img width="914" height="568" alt="image" src="https://github.com/user-attachments/assets/63b5ac2a-63e4-4392-aa6c-7f208bcd669e" />