### PR TITLE
fix(text-selection): AX focus resolution, double-click selection, and screenshot tool conflict

### DIFF
--- a/Sources/Core/TextSelection/AccessibilityGrabber.swift
+++ b/Sources/Core/TextSelection/AccessibilityGrabber.swift
@@ -1,7 +1,10 @@
 import AppKit
 import ApplicationServices
+import os
 
 enum AccessibilityGrabber {
+    private static let log = Logger(subsystem: "com.nahida.MoePeek", category: "AccessibilityGrabber")
+
     /// Read the selected text from the frontmost application using the Accessibility API.
     /// Returns nil if no text is selected or the app doesn't support AX text selection.
     ///
@@ -11,23 +14,7 @@ enum AccessibilityGrabber {
     ///   (bottom-left origin).
     @MainActor
     static func grabSelectedText(near clickPoint: CGPoint? = nil) -> String? {
-        guard let frontApp = NSWorkspace.shared.frontmostApplication else { return nil }
-
-        let appElement = AXUIElementCreateApplication(frontApp.processIdentifier)
-
-        var focusedValue: CFTypeRef?
-        let focusResult = AXUIElementCopyAttributeValue(
-            appElement,
-            kAXFocusedUIElementAttribute as CFString,
-            &focusedValue
-        )
-        guard focusResult == .success,
-              let focusedRef = focusedValue,
-              CFGetTypeID(focusedRef) == AXUIElementGetTypeID()
-        else { return nil }
-
-        // Safe: CFGetTypeID verified above; as?/as! cannot express CF type casts cleanly.
-        let focusedElement = unsafeBitCast(focusedRef, to: AXUIElement.self)
+        guard let focusedElement = copyFocusedElement() else { return nil }
 
         var selectedValue: CFTypeRef?
         let selectResult = AXUIElementCopyAttributeValue(
@@ -36,6 +23,7 @@ enum AccessibilityGrabber {
             &selectedValue
         )
         guard selectResult == .success, let text = selectedValue as? String, !text.isEmpty else {
+            log.debug("kAXSelectedTextAttribute unavailable (status: \(selectResult.rawValue, privacy: .public))")
             return nil
         }
 
@@ -75,5 +63,55 @@ enum AccessibilityGrabber {
         }
 
         return text
+    }
+
+    /// Resolve the currently focused UI element. Tries the frontmost app's element first, then
+    /// falls back to the system-wide element — some apps (and newer macOS releases) expose the
+    /// focused element only via the system-wide accessibility object. See issue #75.
+    @MainActor
+    private static func copyFocusedElement() -> AXUIElement? {
+        guard let frontApp = NSWorkspace.shared.frontmostApplication else {
+            log.debug("no frontmost application")
+            return nil
+        }
+
+        let appElement = AXUIElementCreateApplication(frontApp.processIdentifier)
+        if let element = copyFocusedUIElement(of: appElement) {
+            return element
+        }
+        log.debug("app-level focused element unavailable for \(frontApp.bundleIdentifier ?? "?", privacy: .public)")
+
+        guard let element = copyFocusedUIElement(of: AXUIElementCreateSystemWide()) else {
+            log.debug("system-wide focused element unavailable")
+            return nil
+        }
+
+        // The system-wide object can hand back an element owned by another process — a
+        // non-activating panel holding key focus, for instance. Callers scope exclusions and
+        // stale-selection checks to the frontmost app, so reject anything outside it.
+        var elementPID: pid_t = 0
+        guard AXUIElementGetPid(element, &elementPID) == .success,
+              elementPID == frontApp.processIdentifier
+        else {
+            log.debug("system-wide focused element belongs to another process")
+            return nil
+        }
+        return element
+    }
+
+    private static func copyFocusedUIElement(of element: AXUIElement) -> AXUIElement? {
+        var focusedValue: CFTypeRef?
+        let focusResult = AXUIElementCopyAttributeValue(
+            element,
+            kAXFocusedUIElementAttribute as CFString,
+            &focusedValue
+        )
+        guard focusResult == .success,
+              let focusedRef = focusedValue,
+              CFGetTypeID(focusedRef) == AXUIElementGetTypeID()
+        else { return nil }
+
+        // Safe: CFGetTypeID verified above; as?/as! cannot express CF type casts cleanly.
+        return unsafeBitCast(focusedRef, to: AXUIElement.self)
     }
 }

--- a/Sources/Core/TextSelection/ClipboardGrabber.swift
+++ b/Sources/Core/TextSelection/ClipboardGrabber.swift
@@ -14,6 +14,10 @@ enum ClipboardGrabber {
     /// Saves and restores the previous clipboard content, unless an external
     /// modification (real user ⌘+C) is detected during the grab window.
     @MainActor static func grabViaClipboard() async -> String? {
+        // Skip synthesizing ⌘C while a screenshot tool's capture overlay is on screen —
+        // it would swallow the keypress as its own shortcut and abort the capture. See issue #67.
+        guard !ScreenshotOverlayDetector.isCapturingScreenshot() else { return nil }
+
         guard isGrabbing.withLock({ val in
             if val { return false }
             val = true

--- a/Sources/Core/TextSelection/ScreenshotOverlayDetector.swift
+++ b/Sources/Core/TextSelection/ScreenshotOverlayDetector.swift
@@ -45,14 +45,14 @@ enum ScreenshotOverlayDetector {
 
         for window in windows {
             guard let layer = window[kCGWindowLayer as String] as? Int, layer > 0,
-                  let bounds = window[kCGWindowBounds as String] as? [String: CGFloat],
-                  let x = bounds["X"], let y = bounds["Y"],
-                  let width = bounds["Width"], let height = bounds["Height"],
-                  coversWholeDisplay(CGRect(x: x, y: y, width: width, height: height), displays),
-                  let pid = window[kCGWindowOwnerPID as String] as? pid_t
+                  let boundsDictionary = window[kCGWindowBounds as String] as? [String: Any],
+                  let bounds = CGRect(dictionaryRepresentation: boundsDictionary as CFDictionary),
+                  coversWholeDisplay(bounds, displays),
+                  let pidValue = window[kCGWindowOwnerPID as String] as? Int,
+                  let pid = pid_t(exactly: pidValue)
             else { continue }
 
-            if pid == frontmostPID { return true }
+            if let frontmostPID, pid == frontmostPID { return true }
             if let bundleID = NSRunningApplication(processIdentifier: pid)?.bundleIdentifier,
                captureToolBundleIDs.contains(bundleID.lowercased()) {
                 return true

--- a/Sources/Core/TextSelection/ScreenshotOverlayDetector.swift
+++ b/Sources/Core/TextSelection/ScreenshotOverlayDetector.swift
@@ -1,0 +1,83 @@
+import AppKit
+import CoreGraphics
+
+/// Detects whether a screenshot tool is mid-capture.
+///
+/// Region-capture tools (CleanShot X, Shottr, Cap, macOS native screenshot, …) present a
+/// fullscreen overlay that swallows keyboard shortcuts. Our Tier 3 grab synthesizes `⌘C`,
+/// which such an overlay interprets as *its own* "copy capture" shortcut and aborts the
+/// capture flow. Callers consult this before synthesizing `⌘C` so they can skip it while a
+/// capture overlay is on screen. See issue #67.
+enum ScreenshotOverlayDetector {
+    /// Bundle IDs of screenshot tools known to present a shortcut-capturing overlay, lowercased
+    /// for case-insensitive comparison (Snipaste ships a mixed-case identifier).
+    private static let captureToolBundleIDs: Set<String> = [
+        "pl.maketheweb.cleanshotx",  // CleanShot X
+        "com.apple.screencaptureui", // macOS native screenshot
+        "cc.ffitch.shottr",          // Shottr
+        "so.cap.desktop",            // Cap
+        "com.zzd.xnip",              // Xnip
+        "com.snipaste",              // Snipaste
+    ]
+
+    /// Fraction of a display an overlay must cover to read as an active capture. Demanding
+    /// near-full coverage keeps a capture tool's *resident* windows — a Snipaste pinned
+    /// screenshot, a CleanShot annotation — from registering as a capture in progress, which
+    /// would disable clipboard grabbing for as long as they stayed on screen.
+    private static let displayCoverageThreshold: CGFloat = 0.9
+
+    /// True when a screenshot capture appears to be in progress.
+    ///
+    /// Looks for an above-normal-layer window covering a whole display, owned by either a known
+    /// capture tool or the frontmost app. The frontmost check extends the fix to unlisted tools
+    /// while still ignoring persistent background overlays (screen dimmers, pinned images),
+    /// which never hold focus while the user is selecting text elsewhere.
+    @MainActor
+    static func isCapturingScreenshot() -> Bool {
+        let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
+        guard let windows = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] else {
+            return false
+        }
+
+        let displays = displayRectsInWindowSpace()
+        guard !displays.isEmpty else { return false }
+        let frontmostPID = NSWorkspace.shared.frontmostApplication?.processIdentifier
+
+        for window in windows {
+            guard let layer = window[kCGWindowLayer as String] as? Int, layer > 0,
+                  let bounds = window[kCGWindowBounds as String] as? [String: CGFloat],
+                  let x = bounds["X"], let y = bounds["Y"],
+                  let width = bounds["Width"], let height = bounds["Height"],
+                  coversWholeDisplay(CGRect(x: x, y: y, width: width, height: height), displays),
+                  let pid = window[kCGWindowOwnerPID as String] as? pid_t
+            else { continue }
+
+            if pid == frontmostPID { return true }
+            if let bundleID = NSRunningApplication(processIdentifier: pid)?.bundleIdentifier,
+               captureToolBundleIDs.contains(bundleID.lowercased()) {
+                return true
+            }
+        }
+        return false
+    }
+
+    /// `NSScreen.frame` measures from the bottom-left of the primary display while
+    /// `kCGWindowBounds` measures from its top-left, so flip the screen rects before comparing.
+    @MainActor
+    private static func displayRectsInWindowSpace() -> [CGRect] {
+        guard let primaryMaxY = NSScreen.screens.first?.frame.maxY else { return [] }
+        return NSScreen.screens.map { screen in
+            let frame = screen.frame
+            return CGRect(x: frame.minX, y: primaryMaxY - frame.maxY, width: frame.width, height: frame.height)
+        }
+    }
+
+    /// Compares the overlay against each display individually — a threshold derived from the
+    /// largest display would miss a fullscreen overlay on a small secondary monitor.
+    private static func coversWholeDisplay(_ rect: CGRect, _ displays: [CGRect]) -> Bool {
+        displays.contains { display in
+            let overlap = display.intersection(rect)
+            return overlap.width * overlap.height >= display.width * display.height * displayCoverageThreshold
+        }
+    }
+}

--- a/Sources/Core/TextSelection/SelectionMonitor.swift
+++ b/Sources/Core/TextSelection/SelectionMonitor.swift
@@ -98,24 +98,25 @@ final class SelectionMonitor {
             guard let self, !Task.isCancelled else { return }
 
             // Tier 1: Accessibility API — fast, non-invasive
-            if let text = AccessibilityGrabber.grabSelectedText(near: point),
-               !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                self.onTextSelected?(text, point)
-                return
-            }
+            if self.deliver(AccessibilityGrabber.grabSelectedText(near: point), at: point) { return }
 
             // Only attempt fallback tiers if the gesture looks like a selection
             guard wasDragOrMultiClick else { return }
+
+            // Double-click word selection updates the AX selection with a delay; the first
+            // Tier 1 read can miss it and fall through to the clipboard tiers, which may
+            // surface stale clipboard content instead. Retry Tier 1 once. See issue #59.
+            if clickCount >= 2 {
+                try? await Task.sleep(for: .milliseconds(120))
+                guard !Task.isCancelled else { return }
+                if self.deliver(AccessibilityGrabber.grabSelectedText(near: point), at: point) { return }
+            }
 
             // Conservative mode: only AX API, stop here
             guard mode != .conservative else { return }
 
             // Tier 2: AppleScript — Safari-specific JS selection (Finder won't match)
-            if let text = await AppleScriptGrabber.grabFromSafari(),
-               !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                self.onTextSelected?(text, point)
-                return
-            }
+            if self.deliver(await AppleScriptGrabber.grabFromSafari(), at: point) { return }
 
             guard !Task.isCancelled else { return }
 
@@ -130,20 +131,19 @@ final class SelectionMonitor {
                     return
                 }
 
-                if let text = NSPasteboard.general.string(forType: .string),
-                   !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                    self.onTextSelected?(text, point)
-                    return
-                }
+                if self.deliver(NSPasteboard.general.string(forType: .string), at: point) { return }
             }
 
             // Tier 3: Clipboard — simulate ⌘C, read pasteboard, restore
-            if let text = await ClipboardGrabber.grabViaClipboard(),
-               !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                self.onTextSelected?(text, point)
-                return
-            }
+            _ = self.deliver(await ClipboardGrabber.grabViaClipboard(), at: point)
         }
     }
 
+    /// Hands `text` to `onTextSelected` when it carries non-whitespace content, keeping the
+    /// acceptance rule every grab tier shares in one place. Returns true when delivered.
+    private func deliver(_ text: String?, at point: CGPoint) -> Bool {
+        guard let text, !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return false }
+        onTextSelected?(text, point)
+        return true
+    }
 }


### PR DESCRIPTION
Fixes three mouse text-selection bugs and adds screenshot overlay detection.

Closes #75
Closes #59
Closes #67

## Changes

**#75 — Mouse selection fails to trigger the floating icon.** `AccessibilityGrabber` only read `kAXFocusedUIElementAttribute` from the frontmost application, but some apps (and newer macOS releases) expose the focused element solely through the system-wide accessibility object, so Tier 1 failed outright. A system-wide fallback now covers that case, and each failure step logs through `Logger` to make user-reported cases diagnosable.

The fallback validates via `AXUIElementGetPid` that the resolved element belongs to the frontmost process. The system-wide object can hand back an element from another process — a non-activating password manager panel holding key focus, for example — while `SelectionMonitor`'s excluded-app list only checks `frontmostApplication`. Without the check, a user-configured privacy exclusion would be silently defeated and a selected secret could be sent to the translation API. The grabber's documented contract was already "read the selected text from the frontmost application", so this keeps it honest.

**#59 — Double-click word selection is sometimes not recognized.** Apps update their AX selection with a delay after a double click, so the first Tier 1 read comes back empty and the flow falls through to the clipboard tiers, which surface stale clipboard content as if it were the selection. Tier 1 is now retried once after 120ms for multi-click gestures.

**#67 — Conflict with CleanShot X.** A screenshot tool's fullscreen overlay interprets our synthesized `⌘C` as its own "copy capture" shortcut and aborts the capture. The new `ScreenshotOverlayDetector` is consulted before Tier 3 synthesizes `⌘C`, which is skipped while a capture is in progress.

## How overlay detection decides

A capture counts as in progress only for a window that is both above the normal window layer and covering nearly all of a single display. Both conditions matter:

- **Compared per display rather than against the largest one.** On a mixed-resolution multi-monitor setup, a fullscreen overlay on a small secondary display can be far smaller than a threshold derived from the main display's area, so a largest-screen threshold misses it.
- **Requires near-full coverage (≥ 90%).** A capture tool's resident windows — a Snipaste pinned screenshot, a CleanShot annotation — never cover a whole display. Without this, such a window would disable clipboard grabbing silently for as long as it stayed on screen.

Window ownership is matched two ways: a bundle-ID allowlist of known capture tools, and a general rule that **the window belongs to the frontmost application**. The latter extends the fix to unlisted tools (iShot, PixPin, …) without breaking screen dimmers and similar persistent fullscreen overlays, which never hold focus.

The Xnip and Snipaste bundle IDs in the allowlist were verified and corrected (`com.zzd.Xnip`, `com.Snipaste`), and comparison is now case-insensitive since Snipaste ships a mixed-case identifier.

## Testing

`xcodebuild` succeeds.

Not verified on hardware: only Cap is installed locally, so the 90% coverage threshold and the frontmost-application rule have not been exercised against CleanShot X, Snipaste, or Xnip. Native macOS screenshot goes through the allowlist path, since `com.apple.screencaptureui` is an agent process and may not register as `frontmostApplication`.
