### PR TITLE
feat(popup): add configurable local swap shortcut

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -1,6 +1,17 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    " · %@ Swap" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " · %@ 互换语言"
+          }
+        }
+      }
+    },
     "(default)" : {
       "localizations" : {
         "zh-Hans" : {
@@ -58,6 +69,7 @@
       }
     },
     "↵ Translate · ⌘↵ Copy & Close · ⇧↵ Newline" : {
+      "extractionState" : "stale",
       "localizations" : {
         "zh-Hans" : {
           "stringUnit" : {
@@ -848,6 +860,7 @@
       }
     },
     "Floating Icon Activation:" : {
+      "extractionState" : "stale",
       "localizations" : {
         "zh-Hans" : {
           "stringUnit" : {
@@ -2398,6 +2411,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "支持工具调用"
+          }
+        }
+      }
+    },
+    "Swap Languages:" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "互换语言："
           }
         }
       }

--- a/Sources/UI/PopupPanel/PopupPanel.swift
+++ b/Sources/UI/PopupPanel/PopupPanel.swift
@@ -21,6 +21,7 @@ enum PopupPanelViewIdentifier {
 /// A floating, non-activating panel for showing translation results near the cursor.
 final class PopupPanel: NSPanel {
     var onCopyResultShortcut: ((Int) -> Bool)?
+    var onSwapLanguagesShortcut: ((NSEvent) -> Bool)?
 
     /// Set when `focusSourceInput()` is called before the source text view has been mounted.
     /// `SubmitAwareTextView.viewDidMoveToWindow` consumes this flag once the view attaches.
@@ -90,6 +91,11 @@ final class PopupPanel: NSPanel {
     /// Intercepts left-mouse-down on non-interactive areas to start a window drag,
     /// while letting interactive controls (text views, buttons, gesture views) handle events normally.
     override func sendEvent(_ event: NSEvent) {
+        if event.type == .keyDown,
+           onSwapLanguagesShortcut?(event) == true {
+            return
+        }
+
         if event.type == .keyDown,
            let resultIndex = copyResultShortcutIndex(for: event),
            onCopyResultShortcut?(resultIndex) == true {

--- a/Sources/UI/PopupPanel/PopupView.swift
+++ b/Sources/UI/PopupPanel/PopupView.swift
@@ -146,6 +146,9 @@ struct PopupView: View {
                     onCopyAndClose: {
                         copySourceAndClose()
                     },
+                    onSwapLanguages: {
+                        swapLanguages()
+                    },
                     onContentHeightChange: { preferredHeight in
                         expandInputHeightIfNeeded(for: preferredHeight)
                     }
@@ -171,14 +174,7 @@ struct PopupView: View {
                         detectionConfidence: coordinator.detectionResult?.confidence,
                         targetLanguage: $targetLang,
                         onSwap: {
-                            let effectiveSource = sourceLang == "auto"
-                            ? (coordinator.detectedLanguage ?? targetLang)
-                            : sourceLang
-                            // When auto-detect has no result yet, effectiveSource falls back
-                            // to targetLang and swap becomes a no-op
-                            guard effectiveSource != targetLang else { return }
-                            sourceLang = targetLang
-                            targetLang = effectiveSource
+                            swapLanguages()
                         }
                     )
 
@@ -274,6 +270,17 @@ struct PopupView: View {
         let targetHeight = min(max(preferredHeight, baseline), maxInputHeight)
         guard abs(targetHeight - inputHeight) > 0.5 else { return }
         inputHeight = targetHeight
+    }
+
+    private func swapLanguages() {
+        let effectiveSource = sourceLang == "auto"
+        ? (coordinator.detectedLanguage ?? targetLang)
+        : sourceLang
+        // When auto-detect has no result yet, effectiveSource falls back
+        // to targetLang and swap becomes a no-op
+        guard effectiveSource != targetLang else { return }
+        sourceLang = targetLang
+        targetLang = effectiveSource
     }
 
     private func copySourceAndClose() {

--- a/Sources/UI/PopupPanel/SourceInputView.swift
+++ b/Sources/UI/PopupPanel/SourceInputView.swift
@@ -18,6 +18,7 @@ struct SourceInputView: View {
     // Keyboard shortcuts only reach the panel when it is the key window (e.g. selection
     // translation shows the panel without focus); dim the hints when they wouldn't work.
     @State private var isWindowKey = false
+    @State private var swapShortcut = SwapLanguagesShortcut.current
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -72,13 +73,16 @@ struct SourceInputView: View {
                     .opacity(isWindowKey ? 1 : 0.4)
             }
         }
+        .onReceive(NotificationCenter.default.publisher(for: SwapLanguagesShortcut.didChangeNotification)) { _ in
+            swapShortcut = SwapLanguagesShortcut.current
+        }
     }
 
     /// The swap shortcut is user-configurable, so the hint shows whatever is currently
     /// bound and drops that segment entirely once the user clears the binding.
     private var shortcutHint: String {
         let base = String(localized: "↵ Translate · ⌘↵ Copy & Close · ⇧↵ Newline")
-        guard let swap = KeyboardShortcuts.getShortcut(for: .swapLanguages) else { return base }
+        guard let swap = swapShortcut else { return base }
         return base + String(localized: " · \(swap.description) Swap")
     }
 
@@ -306,6 +310,13 @@ private final class SubmitAwareTextView: NSTextView {
     }
 
     override func keyDown(with event: NSEvent) {
+        if !hasMarkedText(), SwapLanguagesShortcut.matches(event) {
+            if !event.isARepeat {
+                onSwapLanguages?()
+            }
+            return
+        }
+
         let isReturnKey = event.keyCode == 36 || event.keyCode == 76
         let hasShift = event.modifierFlags.contains(.shift)
         let hasCommand = event.modifierFlags.contains(.command)
@@ -321,15 +332,6 @@ private final class SubmitAwareTextView: NSTextView {
         if isReturnKey, !hasCommand, !hasShift, !hasMarkedText() {
             guard !string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
             onSubmit?()
-            return
-        }
-
-        // User-configurable shortcut that swaps source/target languages
-        // (mirrors the swap button in LanguageBarView).
-        if !hasMarkedText(),
-           let configured = KeyboardShortcuts.getShortcut(for: .swapLanguages),
-           KeyboardShortcuts.Shortcut(event: event) == configured {
-            onSwapLanguages?()
             return
         }
 

--- a/Sources/UI/PopupPanel/SourceInputView.swift
+++ b/Sources/UI/PopupPanel/SourceInputView.swift
@@ -274,6 +274,9 @@ private final class SubmitAwareTextView: NSTextView {
         // Event-driven first responder handoff: when SwiftUI mounts this text view into
         // the panel, consume the panel's one-shot focus request set by `focusSourceInput()`.
         guard let panel = window as? PopupPanel else { return }
+        panel.onSwapLanguagesShortcut = { [weak self] event in
+            self?.handleSwapLanguagesShortcut(event) ?? false
+        }
         panel.consumePendingSourceInputFocus(into: self)
     }
 
@@ -309,14 +312,15 @@ private final class SubmitAwareTextView: NSTextView {
         onWindowKeyChange?(window?.isKeyWindow ?? false)
     }
 
-    override func keyDown(with event: NSEvent) {
-        if !hasMarkedText(), SwapLanguagesShortcut.matches(event) {
-            if !event.isARepeat {
-                onSwapLanguages?()
-            }
-            return
+    private func handleSwapLanguagesShortcut(_ event: NSEvent) -> Bool {
+        guard !hasMarkedText(), SwapLanguagesShortcut.matches(event) else { return false }
+        if !event.isARepeat {
+            onSwapLanguages?()
         }
+        return true
+    }
 
+    override func keyDown(with event: NSEvent) {
         let isReturnKey = event.keyCode == 36 || event.keyCode == 76
         let hasShift = event.modifierFlags.contains(.shift)
         let hasCommand = event.modifierFlags.contains(.command)

--- a/Sources/UI/PopupPanel/SourceInputView.swift
+++ b/Sources/UI/PopupPanel/SourceInputView.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Defaults
+import KeyboardShortcuts
 import SwiftUI
 
 /// Editable source text input with Enter to translate, Shift+Enter for newline.
@@ -8,11 +9,15 @@ struct SourceInputView: View {
     let sourceLanguage: String
     let onSubmit: () -> Void
     let onCopyAndClose: () -> Void
+    let onSwapLanguages: () -> Void
     var onContentHeightChange: ((CGFloat) -> Void)?
     @Default(.popupFontSize) private var fontSize
     @Default(.popupFontName) private var fontName
     @Default(.ttsAccent) private var ttsAccent
     @Environment(\.ttsCoordinator) private var ttsCoordinator
+    // Keyboard shortcuts only reach the panel when it is the key window (e.g. selection
+    // translation shows the panel without focus); dim the hints when they wouldn't work.
+    @State private var isWindowKey = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -22,6 +27,10 @@ struct SourceInputView: View {
                 fontName: fontName,
                 onSubmit: onSubmit,
                 onCopyAndClose: onCopyAndClose,
+                onSwapLanguages: onSwapLanguages,
+                onWindowKeyChange: { isKey in
+                    isWindowKey = isKey
+                },
                 onContentHeightChange: { editorHeight in
                     onContentHeightChange?(sourceInputHeight(forEditorHeight: editorHeight))
                 }
@@ -57,11 +66,20 @@ struct SourceInputView: View {
 
                 Spacer()
 
-                Text("↵ Translate · ⌘↵ Copy & Close · ⇧↵ Newline")
+                Text(shortcutHint)
                     .font(.popup(name: fontName, size: CGFloat(fontSize - 4)))
                     .foregroundStyle(.quaternary)
+                    .opacity(isWindowKey ? 1 : 0.4)
             }
         }
+    }
+
+    /// The swap shortcut is user-configurable, so the hint shows whatever is currently
+    /// bound and drops that segment entirely once the user clears the binding.
+    private var shortcutHint: String {
+        let base = String(localized: "↵ Translate · ⌘↵ Copy & Close · ⇧↵ Newline")
+        guard let swap = KeyboardShortcuts.getShortcut(for: .swapLanguages) else { return base }
+        return base + String(localized: " · \(swap.description) Swap")
     }
 
     private func sourceInputHeight(forEditorHeight editorHeight: CGFloat) -> CGFloat {
@@ -77,6 +95,8 @@ private struct SourceTextEditor: NSViewRepresentable {
     let fontName: String
     let onSubmit: () -> Void
     let onCopyAndClose: () -> Void
+    let onSwapLanguages: () -> Void
+    let onWindowKeyChange: (Bool) -> Void
     let onContentHeightChange: (CGFloat) -> Void
 
     private var resolvedFont: NSFont {
@@ -121,6 +141,8 @@ private struct SourceTextEditor: NSViewRepresentable {
         textView.textContainerInset = .zero
         textView.onSubmit = onSubmit
         textView.onCopyAndClose = onCopyAndClose
+        textView.onSwapLanguages = onSwapLanguages
+        textView.onWindowKeyChange = onWindowKeyChange
         textView.textContainer?.containerSize = NSSize(
             width: contentSize.width,
             height: CGFloat.greatestFiniteMagnitude
@@ -158,6 +180,8 @@ private struct SourceTextEditor: NSViewRepresentable {
 
         textView.onSubmit = onSubmit
         textView.onCopyAndClose = onCopyAndClose
+        textView.onSwapLanguages = onSwapLanguages
+        textView.onWindowKeyChange = onWindowKeyChange
 
         coordinator.reportContentHeight()
     }
@@ -196,6 +220,8 @@ private struct SourceTextEditor: NSViewRepresentable {
 private final class SubmitAwareTextView: NSTextView {
     var onSubmit: (() -> Void)?
     var onCopyAndClose: (() -> Void)?
+    var onSwapLanguages: (() -> Void)?
+    var onWindowKeyChange: ((Bool) -> Void)?
     private var displayFont: NSFont = .systemFont(ofSize: NSFont.systemFontSize)
 
     func applyDisplayAttributes(font: NSFont) {
@@ -240,10 +266,43 @@ private final class SubmitAwareTextView: NSTextView {
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
+        observeWindowKeyStatus()
         // Event-driven first responder handoff: when SwiftUI mounts this text view into
         // the panel, consume the panel's one-shot focus request set by `focusSourceInput()`.
         guard let panel = window as? PopupPanel else { return }
         panel.consumePendingSourceInputFocus(into: self)
+    }
+
+    /// Tracks whether the hosting panel is the key window, so SwiftUI can dim the
+    /// shortcut hints when keystrokes would go to another app instead.
+    private func observeWindowKeyStatus() {
+        let center = NotificationCenter.default
+        center.removeObserver(self, name: NSWindow.didBecomeKeyNotification, object: nil)
+        center.removeObserver(self, name: NSWindow.didResignKeyNotification, object: nil)
+        guard let window else {
+            onWindowKeyChange?(false)
+            return
+        }
+        center.addObserver(
+            self,
+            selector: #selector(reportWindowKeyStatus),
+            name: NSWindow.didBecomeKeyNotification,
+            object: window
+        )
+        center.addObserver(
+            self,
+            selector: #selector(reportWindowKeyStatus),
+            name: NSWindow.didResignKeyNotification,
+            object: window
+        )
+        // Async so the initial report doesn't mutate SwiftUI state mid view update
+        Task { @MainActor [weak self] in
+            self?.reportWindowKeyStatus()
+        }
+    }
+
+    @objc private func reportWindowKeyStatus() {
+        onWindowKeyChange?(window?.isKeyWindow ?? false)
     }
 
     override func keyDown(with event: NSEvent) {
@@ -262,6 +321,15 @@ private final class SubmitAwareTextView: NSTextView {
         if isReturnKey, !hasCommand, !hasShift, !hasMarkedText() {
             guard !string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
             onSubmit?()
+            return
+        }
+
+        // User-configurable shortcut that swaps source/target languages
+        // (mirrors the swap button in LanguageBarView).
+        if !hasMarkedText(),
+           let configured = KeyboardShortcuts.getShortcut(for: .swapLanguages),
+           KeyboardShortcuts.Shortcut(event: event) == configured {
+            onSwapLanguages?()
             return
         }
 

--- a/Sources/UI/PopupPanel/SourceInputView.swift
+++ b/Sources/UI/PopupPanel/SourceInputView.swift
@@ -70,6 +70,9 @@ struct SourceInputView: View {
                 Text(shortcutHint)
                     .font(.popup(name: fontName, size: CGFloat(fontSize - 4)))
                     .foregroundStyle(.quaternary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.75)
+                    .allowsTightening(true)
                     .opacity(isWindowKey ? 1 : 0.4)
             }
         }

--- a/Sources/UI/Settings/GeneralSettingsView.swift
+++ b/Sources/UI/Settings/GeneralSettingsView.swift
@@ -50,6 +50,8 @@ struct GeneralSettingsView: View {
                 KeyboardShortcuts.Recorder("Screenshot OCR:", name: .ocrScreenshot)
                 KeyboardShortcuts.Recorder("Manual Translation:", name: .inputTranslation)
                 KeyboardShortcuts.Recorder("Clipboard Translation:", name: .clipboardTranslation)
+
+                KeyboardShortcuts.Recorder("Swap Languages:", name: .swapLanguages)
             }
 
             Section("General") {

--- a/Sources/UI/Settings/GeneralSettingsView.swift
+++ b/Sources/UI/Settings/GeneralSettingsView.swift
@@ -51,7 +51,7 @@ struct GeneralSettingsView: View {
                 KeyboardShortcuts.Recorder("Manual Translation:", name: .inputTranslation)
                 KeyboardShortcuts.Recorder("Clipboard Translation:", name: .clipboardTranslation)
 
-                KeyboardShortcuts.Recorder("Swap Languages:", name: .swapLanguages)
+                LocalShortcutRecorder()
             }
 
             Section("General") {

--- a/Sources/UI/Settings/GeneralSettingsView.swift
+++ b/Sources/UI/Settings/GeneralSettingsView.swift
@@ -46,10 +46,10 @@ struct GeneralSettingsView: View {
     var body: some View {
         Form {
             Section("Keyboard Shortcuts") {
-                KeyboardShortcuts.Recorder("Selection Translation:", name: .translateSelection)
-                KeyboardShortcuts.Recorder("Screenshot OCR:", name: .ocrScreenshot)
-                KeyboardShortcuts.Recorder("Manual Translation:", name: .inputTranslation)
-                KeyboardShortcuts.Recorder("Clipboard Translation:", name: .clipboardTranslation)
+                GlobalShortcutRecorder("Selection Translation:", name: .translateSelection)
+                GlobalShortcutRecorder("Screenshot OCR:", name: .ocrScreenshot)
+                GlobalShortcutRecorder("Manual Translation:", name: .inputTranslation)
+                GlobalShortcutRecorder("Clipboard Translation:", name: .clipboardTranslation)
 
                 LocalShortcutRecorder()
             }

--- a/Sources/UI/Settings/LocalShortcutRecorder.swift
+++ b/Sources/UI/Settings/LocalShortcutRecorder.swift
@@ -1,0 +1,21 @@
+import AppKit
+import KeyboardShortcuts
+import SwiftUI
+
+/// Reuses the package recorder while keeping this shortcut local to the popup.
+struct LocalShortcutRecorder: View {
+    @State private var lastAcceptedShortcut = SwapLanguagesShortcut.current
+
+    var body: some View {
+        KeyboardShortcuts.Recorder("Swap Languages:", name: .swapLanguages) { shortcut in
+            if let shortcut, SwapLanguagesShortcut.isReserved(shortcut) {
+                NSSound.beep()
+                KeyboardShortcuts.setShortcut(lastAcceptedShortcut, for: .swapLanguages)
+            } else {
+                lastAcceptedShortcut = shortcut
+            }
+
+            SwapLanguagesShortcut.recorderDidChange()
+        }
+    }
+}

--- a/Sources/UI/Settings/LocalShortcutRecorder.swift
+++ b/Sources/UI/Settings/LocalShortcutRecorder.swift
@@ -2,6 +2,32 @@ import AppKit
 import KeyboardShortcuts
 import SwiftUI
 
+/// Prevents app-wide shortcuts from taking over the popup-local swap binding.
+struct GlobalShortcutRecorder: View {
+    private let title: LocalizedStringKey
+    private let name: KeyboardShortcuts.Name
+    @State private var lastAcceptedShortcut: KeyboardShortcuts.Shortcut?
+
+    init(_ title: LocalizedStringKey, name: KeyboardShortcuts.Name) {
+        self.title = title
+        self.name = name
+        _lastAcceptedShortcut = State(initialValue: KeyboardShortcuts.getShortcut(for: name))
+    }
+
+    var body: some View {
+        KeyboardShortcuts.Recorder(title, name: name) { shortcut in
+            if let shortcut, shortcut == SwapLanguagesShortcut.current {
+                NSSound.beep()
+                KeyboardShortcuts.setShortcut(lastAcceptedShortcut, for: name)
+            } else {
+                lastAcceptedShortcut = shortcut
+            }
+
+            SwapLanguagesShortcut.reconcileRegistrations()
+        }
+    }
+}
+
 /// Reuses the package recorder while keeping this shortcut local to the popup.
 struct LocalShortcutRecorder: View {
     @State private var lastAcceptedShortcut = SwapLanguagesShortcut.current

--- a/Sources/Utilities/Constants.swift
+++ b/Sources/Utilities/Constants.swift
@@ -160,6 +160,46 @@ enum SwapLanguagesShortcut {
         .keypad6, .keypad7, .keypad8, .keypad9,
     ]
 
+    /// `PopupPanel.sendEvent` runs before `NSTextView`, so preserve standard editing and navigation.
+    private static let textEditingShortcuts: Set<KeyboardShortcuts.Shortcut> = [
+        .init(.a, modifiers: .command),
+        .init(.b, modifiers: .command),
+        .init(.c, modifiers: .command),
+        .init(.e, modifiers: .command),
+        .init(.f, modifiers: .command),
+        .init(.f, modifiers: [.command, .option]),
+        .init(.g, modifiers: .command),
+        .init(.g, modifiers: [.command, .shift]),
+        .init(.j, modifiers: .command),
+        .init(.i, modifiers: .command),
+        .init(.u, modifiers: .command),
+        .init(.v, modifiers: .command),
+        .init(.v, modifiers: [.command, .option, .shift]),
+        .init(.x, modifiers: .command),
+        .init(.z, modifiers: .command),
+        .init(.z, modifiers: [.command, .shift]),
+        .init(.leftArrow, modifiers: .command),
+        .init(.rightArrow, modifiers: .command),
+        .init(.upArrow, modifiers: .command),
+        .init(.downArrow, modifiers: .command),
+        .init(.leftArrow, modifiers: [.command, .shift]),
+        .init(.rightArrow, modifiers: [.command, .shift]),
+        .init(.upArrow, modifiers: [.command, .shift]),
+        .init(.downArrow, modifiers: [.command, .shift]),
+        .init(.leftArrow, modifiers: .option),
+        .init(.rightArrow, modifiers: .option),
+        .init(.leftArrow, modifiers: [.option, .shift]),
+        .init(.rightArrow, modifiers: [.option, .shift]),
+        .init(.delete, modifiers: .option),
+        .init(.deleteForward, modifiers: .option),
+        .init(.delete, modifiers: [.option, .shift]),
+        .init(.deleteForward, modifiers: [.option, .shift]),
+        .init(.delete, modifiers: .command),
+        .init(.deleteForward, modifiers: .command),
+        .init(.delete, modifiers: [.command, .shift]),
+        .init(.deleteForward, modifiers: [.command, .shift]),
+    ]
+
     private static let globalShortcutNames: [KeyboardShortcuts.Name] = [
         .translateSelection,
         .ocrScreenshot,
@@ -196,13 +236,17 @@ enum SwapLanguagesShortcut {
     }
 
     static func isReserved(_ shortcut: KeyboardShortcuts.Shortcut) -> Bool {
-        if shortcut.key == .return || shortcut.key == .keypadEnter {
+        if shortcut.key == .return || shortcut.key == .keypadEnter || shortcut.key == .escape {
             return true
         }
 
         if shortcut.modifiers == .command,
            let key = shortcut.key,
            popupReservedNumberKeys.contains(key) {
+            return true
+        }
+
+        if textEditingShortcuts.contains(shortcut) {
             return true
         }
 

--- a/Sources/Utilities/Constants.swift
+++ b/Sources/Utilities/Constants.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Defaults
 import Foundation
 import KeyboardShortcuts
@@ -136,7 +137,58 @@ extension KeyboardShortcuts.Name {
     static let ocrScreenshot = Self("ocrScreenshot", default: .init(.s, modifiers: .option))
     static let inputTranslation = Self("inputTranslation", default: .init(.a, modifiers: .option))
     static let clipboardTranslation = Self("clipboardTranslation", default: .init(.v, modifiers: .option))
-    static let swapLanguages = Self("swapLanguages", default: .init(.t, modifiers: .option))
+    static let swapLanguages: Self = {
+        let name = Self("swapLanguages", default: .init(.t, modifiers: .option))
+        KeyboardShortcuts.disable(name)
+        return name
+    }()
+}
+
+/// Keeps the swap shortcut popup-local even though the package recorder uses global names.
+enum SwapLanguagesShortcut {
+    static let didChangeNotification = Notification.Name("SwapLanguagesShortcutDidChange")
+
+    private static let popupReservedNumberKeys: Set<KeyboardShortcuts.Key> = [
+        .one, .two, .three, .four, .five, .six, .seven, .eight, .nine,
+    ]
+
+    static var current: KeyboardShortcuts.Shortcut? {
+        KeyboardShortcuts.getShortcut(for: .swapLanguages)
+    }
+
+    static func recorderDidChange() {
+        KeyboardShortcuts.disable(.swapLanguages)
+        NotificationCenter.default.post(name: didChangeNotification, object: nil)
+    }
+
+    static func matches(_ event: NSEvent) -> Bool {
+        guard let current, let eventShortcut = KeyboardShortcuts.Shortcut(event: event) else {
+            return false
+        }
+        return eventShortcut == current
+    }
+
+    static func isReserved(_ shortcut: KeyboardShortcuts.Shortcut) -> Bool {
+        if shortcut.key == .return || shortcut.key == .keypadEnter {
+            return true
+        }
+
+        if shortcut.modifiers == .command,
+           let key = shortcut.key,
+           popupReservedNumberKeys.contains(key) {
+            return true
+        }
+
+        let globalShortcutNames: [KeyboardShortcuts.Name] = [
+            .translateSelection,
+            .ocrScreenshot,
+            .inputTranslation,
+            .clipboardTranslation,
+        ]
+        return globalShortcutNames
+            .compactMap { KeyboardShortcuts.getShortcut(for: $0) }
+            .contains(shortcut)
+    }
 }
 
 // MARK: - User Defaults Keys

--- a/Sources/Utilities/Constants.swift
+++ b/Sources/Utilities/Constants.swift
@@ -140,6 +140,7 @@ extension KeyboardShortcuts.Name {
     static let swapLanguages: Self = {
         let name = Self("swapLanguages", default: .init(.t, modifiers: .option))
         KeyboardShortcuts.disable(name)
+        SwapLanguagesShortcut.restoreGlobalRegistrations()
         return name
     }()
 }
@@ -150,6 +151,15 @@ enum SwapLanguagesShortcut {
 
     private static let popupReservedNumberKeys: Set<KeyboardShortcuts.Key> = [
         .one, .two, .three, .four, .five, .six, .seven, .eight, .nine,
+        .keypad1, .keypad2, .keypad3, .keypad4, .keypad5,
+        .keypad6, .keypad7, .keypad8, .keypad9,
+    ]
+
+    private static let globalShortcutNames: [KeyboardShortcuts.Name] = [
+        .translateSelection,
+        .ocrScreenshot,
+        .inputTranslation,
+        .clipboardTranslation,
     ]
 
     static var current: KeyboardShortcuts.Shortcut? {
@@ -157,8 +167,20 @@ enum SwapLanguagesShortcut {
     }
 
     static func recorderDidChange() {
-        KeyboardShortcuts.disable(.swapLanguages)
+        reconcileRegistrations()
         NotificationCenter.default.post(name: didChangeNotification, object: nil)
+    }
+
+    static func reconcileRegistrations() {
+        KeyboardShortcuts.disable(.swapLanguages)
+        restoreGlobalRegistrations()
+    }
+
+    /// `KeyboardShortcuts` unregisters by key combination rather than by name. Re-enable
+    /// the app-wide shortcuts after disabling or reverting this popup-local binding so a
+    /// rejected collision cannot leave an existing global shortcut inactive.
+    static func restoreGlobalRegistrations() {
+        KeyboardShortcuts.enable(globalShortcutNames)
     }
 
     static func matches(_ event: NSEvent) -> Bool {
@@ -179,12 +201,6 @@ enum SwapLanguagesShortcut {
             return true
         }
 
-        let globalShortcutNames: [KeyboardShortcuts.Name] = [
-            .translateSelection,
-            .ocrScreenshot,
-            .inputTranslation,
-            .clipboardTranslation,
-        ]
         return globalShortcutNames
             .compactMap { KeyboardShortcuts.getShortcut(for: $0) }
             .contains(shortcut)

--- a/Sources/Utilities/Constants.swift
+++ b/Sources/Utilities/Constants.swift
@@ -136,6 +136,7 @@ extension KeyboardShortcuts.Name {
     static let ocrScreenshot = Self("ocrScreenshot", default: .init(.s, modifiers: .option))
     static let inputTranslation = Self("inputTranslation", default: .init(.a, modifiers: .option))
     static let clipboardTranslation = Self("clipboardTranslation", default: .init(.v, modifiers: .option))
+    static let swapLanguages = Self("swapLanguages", default: .init(.t, modifiers: .option))
 }
 
 // MARK: - User Defaults Keys

--- a/Sources/Utilities/Constants.swift
+++ b/Sources/Utilities/Constants.swift
@@ -139,6 +139,11 @@ extension KeyboardShortcuts.Name {
     static let clipboardTranslation = Self("clipboardTranslation", default: .init(.v, modifiers: .option))
     static let swapLanguages: Self = {
         let name = Self("swapLanguages", default: .init(.t, modifiers: .option))
+        // Clear legacy or default bindings that conflict with popup or global actions.
+        if let current = KeyboardShortcuts.getShortcut(for: name),
+           SwapLanguagesShortcut.isReserved(current) {
+            KeyboardShortcuts.setShortcut(nil, for: name)
+        }
         KeyboardShortcuts.disable(name)
         SwapLanguagesShortcut.restoreGlobalRegistrations()
         return name


### PR DESCRIPTION
## Summary

- Add a configurable popup-local shortcut for swapping source and target languages.
- Keep the swap shortcut out of the global Carbon shortcut registry.
- Harden shortcut collision handling for reserved popup actions and existing global shortcuts.
- Improve text selection and provider connection error handling.

## Changed files

- Add local swap shortcut handling in the popup panel and source editor.
- Add shortcut recording and conflict restoration in Settings.
- Add localized shortcut hints.
- Fix AX focus resolution, double-click selection timing, and screenshot-overlay Cmd+C conflicts.
- Show full connection-test error messages for OpenAI-compatible and local providers.

## Risk and validation

Keyboard shortcut registration and NSPanel event routing are affected. Verify:

- Popup-local swap shortcut behavior.
- Existing global shortcuts remain functional.
- Return, keypad Enter, Cmd+1...Cmd+9, IME composition, and key-repeat behavior.
- Selection, OCR, clipboard, and manual input flows.

Local validation:
`tuist generate --no-open`
`xcodebuild -workspace MoePeek.xcworkspace -scheme MoePeek -configuration Debug CODE_SIGNING_ALLOWED=NO build`