### PR TITLE
docs: fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Built with:
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=cosZone/MoePeek&type=date&legend=top-left)](https://www.star-history.com/#cosZone/MoePeek&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=cosZone/MoePeek&type=date&legend=top-left)](https://star-history.dera.page/#cosZone/MoePeek&type=date&legend=top-left)
 
 ## License
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -164,7 +164,7 @@ MoePeek 的诞生受到了 [Easydict](https://github.com/tisfeng/Easydict) 和 [
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=cosZone/MoePeek&type=date&legend=top-left)](https://www.star-history.com/#cosZone/MoePeek&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=cosZone/MoePeek&type=date&legend=top-left)](https://star-history.dera.page/#cosZone/MoePeek&type=date&legend=top-left)
 
 ## 许可证
 


### PR DESCRIPTION
The star history chart in both README files is broken and no longer renders correctly. This change updates the chart links to the working star-history.dera.page service so the charts display again for all readers.