### PR TITLE
feat(popup): render Markdown translation results

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,14 @@ jobs:
       - name: Resolve dependencies and generate project
         run: tuist install && tuist generate
 
+      # Textual pulls in swiftui-math, whose bundled math fonts add ~7 MB. MoePeek never enables
+      # the math syntax extension and SwiftUIMath loads fonts lazily, so the files are dead weight.
+      # Deleting them before the build keeps the code signature intact.
+      - name: Strip unused math fonts
+        run: |
+          find .build/checkouts/swiftui-math/Sources/SwiftUIMath/mathFonts.bundle \
+            \( -name '*.otf' -o -name '*.plist' \) -delete
+
       - name: Determine version
         id: version
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,14 +20,14 @@ xcodebuild -workspace MoePeek.xcworkspace -scheme MoePeek -configuration Debug b
 open MoePeek.xcworkspace
 ```
 
-No tests, linting, or CI/CD are currently configured.
+Unit tests live in `Tests/` (Swift Testing, target `MoePeekTests`); run with `xcodebuild test -workspace MoePeek.xcworkspace -scheme MoePeek`. No linting is configured.
 
 ## Tech Stack
 
 - **Swift 6.0+** with `SWIFT_STRICT_CONCURRENCY: complete`
-- **macOS 14.0+** deployment target, LSUIElement (menu bar app, no Dock icon)
+- **macOS 15.0+** deployment target, LSUIElement (menu bar app, no Dock icon)
 - **SwiftUI + AppKit hybrid**: SwiftUI for views, AppKit NSPanel for non-activating floating windows
-- **Dependencies**: KeyboardShortcuts (sindresorhus), Defaults (sindresorhus)
+- **Dependencies**: KeyboardShortcuts (sindresorhus), Defaults (sindresorhus), Sparkle, Textual (gonzalezreal, Markdown rendering)
 - **License**: AGPL-3.0
 
 ## Architecture

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fa4d4cdac894141443ac50933a622832baacec81afaee21393e5e9f1d89dd136",
+  "originHash" : "3536b4295079664d4c59c8e5433a6178af76138885641c31029fd4723e674299",
   "pins" : [
     {
       "identity" : "defaults",
@@ -29,12 +29,39 @@
       }
     },
     {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "5fa253428866f2360c3754e88537f700ed2656b5",
+        "version" : "1.4.1"
+      }
+    },
+    {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
         "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
         "version" : "602.0.0"
+      }
+    },
+    {
+      "identity" : "swiftui-math",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gonzalezreal/swiftui-math",
+      "state" : {
+        "revision" : "0b5c2cfaaec8d6193db206f675048eeb5ce95f71",
+        "version" : "0.1.0"
+      }
+    },
+    {
+      "identity" : "textual",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gonzalezreal/textual",
+      "state" : {
+        "revision" : "01b51875a5406eefc95f52a058cb059e7bc94dc4",
+        "version" : "0.5.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -7,5 +7,6 @@ let package = Package(
         .package(url: "https://github.com/sindresorhus/KeyboardShortcuts", exact: "2.3.0"),
         .package(url: "https://github.com/sindresorhus/Defaults", from: "9.0.0"),
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.0.0"),
+        .package(url: "https://github.com/gonzalezreal/textual", from: "0.5.0"),
     ]
 )

--- a/Project.swift
+++ b/Project.swift
@@ -22,7 +22,7 @@ let project = Project(
             destinations: .macOS,
             product: .app,
             bundleId: "com.nahida.MoePeek",
-            deploymentTargets: .macOS("14.0"),
+            deploymentTargets: .macOS("15.0"),
             infoPlist: .extendingDefault(with: [
                 "CFBundleDevelopmentRegion": "en",
                 "CFBundleShortVersionString": "$(MARKETING_VERSION)",
@@ -43,6 +43,7 @@ let project = Project(
                 .external(name: "KeyboardShortcuts"),
                 .external(name: "Defaults"),
                 .external(name: "Sparkle"),
+                .external(name: "Textual"),
             ],
             settings: .settings(
                 base: [
@@ -57,6 +58,17 @@ let project = Project(
                     .release(name: "Release", xcconfig: "Configurations/Signing.xcconfig"),
                 ]
             )
+        ),
+        .target(
+            name: "MoePeekTests",
+            destinations: .macOS,
+            product: .unitTests,
+            bundleId: "com.nahida.MoePeekTests",
+            deploymentTargets: .macOS("15.0"),
+            sources: ["Tests/**"],
+            dependencies: [
+                .target(name: "MoePeek"),
+            ]
         ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 <p align="center">
   <a href="https://github.com/cosZone/MoePeek/releases/latest"><img src="https://img.shields.io/github/v/release/cosZone/MoePeek" alt="GitHub Release" /></a>
   <a href="https://github.com/cosZone/MoePeek/releases"><img src="https://img.shields.io/github/downloads/cosZone/MoePeek/total" alt="Downloads" /></a>
-  <img src="https://img.shields.io/badge/platform-macOS%2014%2B-blue" alt="Platform" />
+  <img src="https://img.shields.io/badge/platform-macOS%2015%2B-blue" alt="Platform" />
   <img src="https://img.shields.io/badge/swift-6.0-orange" alt="Swift" />
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-green" alt="License" /></a>
 </p>
@@ -56,7 +56,7 @@
 
 ## Why MoePeek
 
-- **~5 MB app size**: Pure Swift 6, only 3 dependencies. No Electron, no WebView.
+- **~7 MB app size**: Pure Swift 6, only 4 dependencies. No Electron, no WebView.
 - **~50 MB background memory**: Systematic memory leak prevention for long-running sessions.
 - **Privacy-friendly**: Apple Translation runs entirely on-device.
 - **Open source**: AGPL-3.0 licensed. Issues and feedback welcome.
@@ -150,6 +150,7 @@ Built with:
 - [KeyboardShortcuts](https://github.com/sindresorhus/KeyboardShortcuts) by Sindre Sorhus
 - [Defaults](https://github.com/sindresorhus/Defaults) by Sindre Sorhus
 - [Sparkle](https://sparkle-project.org/) for auto-updates
+- [Textual](https://github.com/gonzalezreal/textual) for Markdown rendering
 
 ## Contributors
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -15,7 +15,7 @@
 <p align="center">
   <a href="https://github.com/cosZone/MoePeek/releases/latest"><img src="https://img.shields.io/github/v/release/cosZone/MoePeek" alt="GitHub Release" /></a>
   <a href="https://github.com/cosZone/MoePeek/releases"><img src="https://img.shields.io/github/downloads/cosZone/MoePeek/total" alt="Downloads" /></a>
-  <img src="https://img.shields.io/badge/platform-macOS%2014%2B-blue" alt="Platform" />
+  <img src="https://img.shields.io/badge/platform-macOS%2015%2B-blue" alt="Platform" />
   <img src="https://img.shields.io/badge/swift-6.0-orange" alt="Swift" />
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-green" alt="License" /></a>
 </p>
@@ -57,7 +57,7 @@
 
 ## 为什么选择 MoePeek
 
-- **约 5 MB 安装体积**：纯 Swift 6 构建，仅 3 个依赖。没有 Electron，没有 WebView。
+- **约 7 MB 安装体积**：纯 Swift 6 构建，仅 4 个依赖。没有 Electron，没有 WebView。
 - **约 50 MB 后台内存**：系统性防控内存泄漏，长时间挂后台也稳定。
 - **注重隐私**：Apple 翻译完全在设备端运行。
 - **开源项目**：AGPL-3.0 协议，欢迎提 Issue 和反馈。
@@ -151,6 +151,7 @@ MoePeek 的诞生受到了 [Easydict](https://github.com/tisfeng/Easydict) 和 [
 - [KeyboardShortcuts](https://github.com/sindresorhus/KeyboardShortcuts)：Sindre Sorhus
 - [Defaults](https://github.com/sindresorhus/Defaults)：Sindre Sorhus
 - [Sparkle](https://sparkle-project.org/)：自动更新
+- [Textual](https://github.com/gonzalezreal/textual)：Markdown 渲染
 
 ## 贡献者
 

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -1,6 +1,66 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "Source" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "源码"
+          }
+        }
+      }
+    },
+    "Markdown" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Markdown"
+          }
+        }
+      }
+    },
+    "Show source text" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示源码"
+          }
+        }
+      }
+    },
+    "Show rendered Markdown" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示渲染后的 Markdown"
+          }
+        }
+      }
+    },
+    "Render Markdown in results" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在翻译结果中渲染 Markdown"
+          }
+        }
+      }
+    },
+    "Image" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "图片"
+          }
+        }
+      }
+    },
     " · %@ Swap" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/Sources/UI/PopupPanel/MarkdownResultView.swift
+++ b/Sources/UI/PopupPanel/MarkdownResultView.swift
@@ -9,18 +9,27 @@ struct MarkdownResultView: View {
     let font: Font
 
     var body: some View {
-        StructuredText(markdown: MarkdownSupport.prepareForRendering(text))
-            .font(font)
-            .textual.textSelection(.enabled)
-            .textual.imageAttachmentLoader(NoRemoteImageLoader())
-            .environment(\.openURL, OpenURLAction { url in
-                guard let imageURL = MarkdownSupport.imageURL(fromPlaceholder: url) else {
-                    return .systemAction
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(Array(MarkdownSupport.renderingSegments(text).enumerated()), id: \.offset) { _, segment in
+                switch segment {
+                case .markdown(let markdown):
+                    StructuredText(markdown: MarkdownSupport.hardenLineBreaks(markdown))
+                        .textual.textSelection(.enabled)
+                        .textual.imageAttachmentLoader(NoRemoteImageLoader())
+                case .image(let placeholder):
+                    Button {
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(placeholder.url.absoluteString, forType: .string)
+                    } label: {
+                        Text(placeholder.label)
+                            .foregroundStyle(Color.accentColor)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(placeholder.label)
                 }
-                NSPasteboard.general.clearContents()
-                NSPasteboard.general.setString(imageURL.absoluteString, forType: .string)
-                return .handled
-            })
+            }
+        }
+        .font(font)
     }
 }
 

--- a/Sources/UI/PopupPanel/MarkdownResultView.swift
+++ b/Sources/UI/PopupPanel/MarkdownResultView.swift
@@ -1,0 +1,33 @@
+import AppKit
+import SwiftUI
+import Textual
+
+/// Renders a completed translation result as Markdown. Remote images are never fetched;
+/// their placeholder links copy the original URL to the clipboard when clicked.
+struct MarkdownResultView: View {
+    let text: String
+    let font: Font
+
+    var body: some View {
+        StructuredText(markdown: MarkdownSupport.prepareForRendering(text))
+            .font(font)
+            .textual.textSelection(.enabled)
+            .textual.imageAttachmentLoader(NoRemoteImageLoader())
+            .environment(\.openURL, OpenURLAction { url in
+                guard let imageURL = MarkdownSupport.imageURL(fromPlaceholder: url) else {
+                    return .systemAction
+                }
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(imageURL.absoluteString, forType: .string)
+                return .handled
+            })
+    }
+}
+
+private struct NoRemoteImageLoader: AttachmentLoader {
+    struct Blocked: Error {}
+
+    func attachment(for url: URL, text: String, environment: ColorEnvironmentValues) async throws -> AnyAttachment {
+        throw Blocked()
+    }
+}

--- a/Sources/UI/PopupPanel/ProviderResultCard.swift
+++ b/Sources/UI/PopupPanel/ProviderResultCard.swift
@@ -16,6 +16,8 @@ struct ProviderResultCard: View {
     @Default(.popupFontSize) private var fontSize
     @Default(.popupFontName) private var fontName
     @Default(.ttsAccent) private var ttsAccent
+    @Default(.renderMarkdownResults) private var renderMarkdownResults
+    @Default(.resultViewMode) private var resultViewMode
     @Environment(\.ttsCoordinator) private var ttsCoordinator
 
     var body: some View {
@@ -130,9 +132,9 @@ struct ProviderResultCard: View {
                 .font(.popup(name: fontName, size: CGFloat(fontSize)))
                 .foregroundStyle(.secondary)
         case let .streaming(partial):
-            resultContent(partial, canSpeak: false)
+            resultContent(partial, isCompleted: false)
         case let .completed(text):
-            resultContent(text, canSpeak: true)
+            resultContent(text, isCompleted: true)
         case let .error(message):
             VStack(alignment: .leading, spacing: 4) {
                 Label(message, systemImage: "exclamationmark.triangle")
@@ -155,17 +157,41 @@ struct ProviderResultCard: View {
         }
     }
 
-    private func resultContent(_ text: String, canSpeak: Bool) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(text)
-                .font(.popup(name: fontName, size: CGFloat(fontSize)))
-                .foregroundStyle(.primary)
-                .textSelection(.enabled)
-                .frame(maxWidth: .infinity, alignment: .leading)
+    private func resultContent(_ text: String, isCompleted: Bool) -> some View {
+        let canSpeak = isCompleted
+        let offersMarkdown = isCompleted && renderMarkdownResults && MarkdownSupport.looksLikeMarkdown(text)
+        let font = Font.popup(name: fontName, size: CGFloat(fontSize))
 
-            if (canSpeak && ttsCoordinator != nil) || onCopy != nil {
+        return VStack(alignment: .leading, spacing: 4) {
+            if offersMarkdown && resultViewMode == .rendered {
+                MarkdownResultView(text: text, font: font)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } else {
+                Text(text)
+                    .font(font)
+                    .foregroundStyle(.primary)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            if offersMarkdown || (canSpeak && ttsCoordinator != nil) || onCopy != nil {
                 HStack {
                     Spacer()
+
+                    if offersMarkdown {
+                        Button {
+                            resultViewMode = resultViewMode == .rendered ? .source : .rendered
+                        } label: {
+                            Label(
+                                resultViewMode == .rendered ? "Source" : "Markdown",
+                                systemImage: resultViewMode == .rendered ? "chevron.left.forwardslash.chevron.right" : "doc.richtext"
+                            )
+                            .font(.popup(name: fontName, size: CGFloat(fontSize - 2)))
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.mini)
+                        .help(resultViewMode == .rendered ? "Show source text" : "Show rendered Markdown")
+                    }
 
                     if canSpeak, let ttsCoordinator {
                         Button {

--- a/Sources/UI/Settings/GeneralSettingsView.swift
+++ b/Sources/UI/Settings/GeneralSettingsView.swift
@@ -15,6 +15,7 @@ struct GeneralSettingsView: View {
     @Default(.popupDefaultHeight) private var popupDefaultHeight
     @Default(.popupFontSize) private var popupFontSize
     @Default(.popupFontName) private var popupFontName
+    @Default(.renderMarkdownResults) private var renderMarkdownResults
     @Default(.popupRememberPosition) private var popupRememberPosition
     @Default(.sourceLanguage) private var sourceLanguage
     @Default(.detectionConfidenceThreshold) private var confidenceThreshold
@@ -206,6 +207,8 @@ struct GeneralSettingsView: View {
                             .tag(family)
                     }
                 }
+
+                Toggle("Render Markdown in results", isOn: $renderMarkdownResults)
             }
         }
         .formStyle(.grouped)

--- a/Sources/Utilities/Constants.swift
+++ b/Sources/Utilities/Constants.swift
@@ -77,6 +77,13 @@ enum TextDetectionMode: String, CaseIterable, Defaults.Serializable {
     case full          // Tier 1 + Tier 2 + Tier 3 (AX + AppleScript + ⌘C simulation)
 }
 
+// MARK: - Result View Mode
+
+enum ResultViewMode: String, Defaults.Serializable {
+    case rendered
+    case source
+}
+
 // MARK: - Menu Bar Icon Style
 
 enum MenuBarIconStyle: String, CaseIterable, Defaults.Serializable {
@@ -300,6 +307,10 @@ extension Defaults.Keys {
     static let popupInputHeight = Key<Int>("popupInputHeight", default: 48)
     static let popupFontSize = Key<Int>("popupFontSize", default: 12)
     static let popupFontName = Key<String>("popupFontName", default: "")
+
+    // Markdown rendering of translation results
+    static let renderMarkdownResults = Key<Bool>("renderMarkdownResults", default: true)
+    static let resultViewMode = Key<ResultViewMode>("resultViewMode", default: .rendered)
 
     // Popup panel last dragged position (used when popupRememberPosition is enabled).
     // We persist the top-left corner so the visual position stays anchored even when the

--- a/Sources/Utilities/MarkdownSupport.swift
+++ b/Sources/Utilities/MarkdownSupport.swift
@@ -1,10 +1,18 @@
 import Foundation
 
+struct MarkdownImagePlaceholder: Equatable {
+    let label: String
+    let url: URL
+}
+
+enum MarkdownRenderingSegment: Equatable {
+    case markdown(String)
+    case image(MarkdownImagePlaceholder)
+}
+
 /// Pure helpers that decide whether a translation result should be rendered as Markdown
 /// and rewrite it into a form the renderer can display without any network access.
 enum MarkdownSupport {
-    static let imagePlaceholderScheme = "moepeek-image"
-
     private static let blockPatterns: [NSRegularExpression] = [
         #"^#{1,6}\s+\S"#,
         #"^\s*[-*+]\s+\S"#,
@@ -36,36 +44,51 @@ enum MarkdownSupport {
         return (blockPatterns + inlinePatterns).contains { $0.firstMatch(in: text, range: range) != nil }
     }
 
-    static func prepareForRendering(_ text: String) -> String {
-        hardenLineBreaks(rewriteImages(text))
-    }
-
-    /// Replaces `![alt](url)` with a link to a private scheme so the renderer never fetches
-    /// remote images. The link label shows the alt text and the image host.
-    static func rewriteImages(_ text: String) -> String {
+    /// Separates images from Textual's link interaction layer so their placeholders can be
+    /// rendered as native buttons while preserving their position in the document.
+    static func renderingSegments(_ text: String) -> [MarkdownRenderingSegment] {
         let nsText = text as NSString
-        var result = text
-        for match in imagePattern.matches(in: text, range: NSRange(location: 0, length: nsText.length)).reversed() {
+        let matches = imagePattern.matches(in: text, range: NSRange(location: 0, length: nsText.length))
+        guard !matches.isEmpty else { return [.markdown(text)] }
+
+        var segments: [MarkdownRenderingSegment] = []
+        var cursor = 0
+
+        func appendMarkdown(_ markdown: String) {
+            guard !markdown.isEmpty else { return }
+            if case .markdown(let previous) = segments.last {
+                segments.removeLast()
+                segments.append(.markdown(previous + markdown))
+            } else {
+                segments.append(.markdown(markdown))
+            }
+        }
+
+        for match in matches {
+            if match.range.location > cursor {
+                appendMarkdown(nsText.substring(with: NSRange(
+                    location: cursor,
+                    length: match.range.location - cursor
+                )))
+            }
+
             let alt = nsText.substring(with: match.range(at: 1))
             let urlString = nsText.substring(with: match.range(at: 2))
-            guard let encoded = urlString.addingPercentEncoding(withAllowedCharacters: .alphanumerics) else { continue }
-            var label = alt.isEmpty ? String(localized: "Image") : alt
-            label = label.replacingOccurrences(of: "[", with: "\\[").replacingOccurrences(of: "]", with: "\\]")
-            if let host = URL(string: urlString)?.host, !host.isEmpty {
-                label += " · \(host)"
+            if let url = URL(string: urlString) {
+                segments.append(.image(.init(
+                    label: imagePlaceholderLabel(alt: alt, urlString: urlString),
+                    url: url
+                )))
+            } else {
+                appendMarkdown(nsText.substring(with: match.range))
             }
-            let replacement = "[🖼 \(label)](\(imagePlaceholderScheme):\(encoded))"
-            let swiftRange = Range(match.range, in: result)!
-            result.replaceSubrange(swiftRange, with: replacement)
+            cursor = NSMaxRange(match.range)
         }
-        return result
-    }
 
-    static func imageURL(fromPlaceholder url: URL) -> URL? {
-        guard url.scheme == imagePlaceholderScheme else { return nil }
-        let encoded = url.absoluteString.dropFirst(imagePlaceholderScheme.count + 1)
-        guard let decoded = String(encoded).removingPercentEncoding else { return nil }
-        return URL(string: decoded)
+        if cursor < nsText.length {
+            appendMarkdown(nsText.substring(from: cursor))
+        }
+        return segments
     }
 
     /// LLM output uses single newlines as visual line breaks, but CommonMark folds them into
@@ -107,5 +130,13 @@ enum MarkdownSupport {
 
     private static func isMatch(_ pattern: String, _ line: String) -> Bool {
         line.range(of: pattern, options: .regularExpression) != nil
+    }
+
+    private static func imagePlaceholderLabel(alt: String, urlString: String) -> String {
+        var label = alt.isEmpty ? String(localized: "Image") : alt
+        if let host = URL(string: urlString)?.host, !host.isEmpty {
+            label += " · \(host)"
+        }
+        return "🖼 \(label)"
     }
 }

--- a/Sources/Utilities/MarkdownSupport.swift
+++ b/Sources/Utilities/MarkdownSupport.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+/// Pure helpers that decide whether a translation result should be rendered as Markdown
+/// and rewrite it into a form the renderer can display without any network access.
+enum MarkdownSupport {
+    static let imagePlaceholderScheme = "moepeek-image"
+
+    private static let blockPatterns: [NSRegularExpression] = [
+        #"^#{1,6}\s+\S"#,
+        #"^\s*[-*+]\s+\S"#,
+        #"^\s*\d+[.)]\s+\S"#,
+        #"^\s*>\s?\S"#,
+        #"^\s*(```|~~~)"#,
+        #"^\s*\|.+\|\s*$"#,
+        #"^\s*([-*_])(\s*\1){2,}\s*$"#,
+    ].map { try! NSRegularExpression(pattern: $0, options: [.anchorsMatchLines]) }
+
+    private static let inlinePatterns: [NSRegularExpression] = [
+        #"\*\*[^*\n]+\*\*"#,
+        #"__[^_\n]+__"#,
+        #"`[^`\n]+`"#,
+        #"~~[^~\n]+~~"#,
+        #"!?\[[^\]\n]*\]\([^)\s]+\)"#,
+    ].map { try! NSRegularExpression(pattern: $0) }
+
+    private static let imagePattern = try! NSRegularExpression(
+        pattern: #"!\[([^\]\n]*)\]\(\s*<?([^)\s>]+)>?(?:\s+"[^"]*")?\s*\)"#
+    )
+
+    private static let blockStartPattern = try! NSRegularExpression(
+        pattern: #"^\s*(#{1,6}\s|[-*+]\s|\d+[.)]\s|>|```|~~~|\||([-*_])(\s*\2){2,}\s*$)"#
+    )
+
+    static func looksLikeMarkdown(_ text: String) -> Bool {
+        let range = NSRange(text.startIndex..., in: text)
+        return (blockPatterns + inlinePatterns).contains { $0.firstMatch(in: text, range: range) != nil }
+    }
+
+    static func prepareForRendering(_ text: String) -> String {
+        hardenLineBreaks(rewriteImages(text))
+    }
+
+    /// Replaces `![alt](url)` with a link to a private scheme so the renderer never fetches
+    /// remote images. The link label shows the alt text and the image host.
+    static func rewriteImages(_ text: String) -> String {
+        let nsText = text as NSString
+        var result = text
+        for match in imagePattern.matches(in: text, range: NSRange(location: 0, length: nsText.length)).reversed() {
+            let alt = nsText.substring(with: match.range(at: 1))
+            let urlString = nsText.substring(with: match.range(at: 2))
+            guard let encoded = urlString.addingPercentEncoding(withAllowedCharacters: .alphanumerics) else { continue }
+            var label = alt.isEmpty ? String(localized: "Image") : alt
+            label = label.replacingOccurrences(of: "[", with: "\\[").replacingOccurrences(of: "]", with: "\\]")
+            if let host = URL(string: urlString)?.host, !host.isEmpty {
+                label += " · \(host)"
+            }
+            let replacement = "[🖼 \(label)](\(imagePlaceholderScheme):\(encoded))"
+            let swiftRange = Range(match.range, in: result)!
+            result.replaceSubrange(swiftRange, with: replacement)
+        }
+        return result
+    }
+
+    static func imageURL(fromPlaceholder url: URL) -> URL? {
+        guard url.scheme == imagePlaceholderScheme else { return nil }
+        let encoded = url.absoluteString.dropFirst(imagePlaceholderScheme.count + 1)
+        guard let decoded = String(encoded).removingPercentEncoding else { return nil }
+        return URL(string: decoded)
+    }
+
+    /// LLM output uses single newlines as visual line breaks, but CommonMark folds them into
+    /// spaces. Appends a hard break to plain lines followed by another plain line. Fenced code
+    /// blocks and block constructs (lists, headings, tables) are left untouched.
+    static func hardenLineBreaks(_ text: String) -> String {
+        let lines = text.components(separatedBy: "\n")
+        var output: [String] = []
+        output.reserveCapacity(lines.count)
+        var inFence = false
+
+        for (index, line) in lines.enumerated() {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("```") || trimmed.hasPrefix("~~~") {
+                inFence.toggle()
+                output.append(line)
+                continue
+            }
+            guard !inFence, !trimmed.isEmpty, index + 1 < lines.count else {
+                output.append(line)
+                continue
+            }
+            let next = lines[index + 1]
+            let nextTrimmed = next.trimmingCharacters(in: .whitespaces)
+            let currentIsHeadingOrTable = isMatch(#"^\s*(#{1,6}\s|\|)"#, line)
+            if nextTrimmed.isEmpty || isBlockStart(next) || currentIsHeadingOrTable
+                || line.hasSuffix("  ") || line.hasSuffix("\\") {
+                output.append(line)
+            } else {
+                output.append(line + "  ")
+            }
+        }
+        return output.joined(separator: "\n")
+    }
+
+    private static func isBlockStart(_ line: String) -> Bool {
+        blockStartPattern.firstMatch(in: line, range: NSRange(line.startIndex..., in: line)) != nil
+    }
+
+    private static func isMatch(_ pattern: String, _ line: String) -> Bool {
+        line.range(of: pattern, options: .regularExpression) != nil
+    }
+}

--- a/Tests/MarkdownSupportTests.swift
+++ b/Tests/MarkdownSupportTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Testing
+@testable import MoePeek
+
+@Suite struct MarkdownSupportTests {
+    @Test func detectsCommonLLMMarkdown() {
+        #expect(MarkdownSupport.looksLikeMarkdown("有以下几种译法：\n\n- **马具**（名词）\n- **利用**（动词）"))
+        #expect(MarkdownSupport.looksLikeMarkdown("## 标题"))
+        #expect(MarkdownSupport.looksLikeMarkdown("1. 第一\n2. 第二"))
+        #expect(MarkdownSupport.looksLikeMarkdown("用 `git status` 查看"))
+        #expect(MarkdownSupport.looksLikeMarkdown("见 [文档](https://example.com)"))
+        #expect(MarkdownSupport.looksLikeMarkdown("```swift\nlet a = 1\n```"))
+    }
+
+    @Test func plainTextIsNotMarkdown() {
+        #expect(!MarkdownSupport.looksLikeMarkdown("Hello world"))
+        #expect(!MarkdownSupport.looksLikeMarkdown("2*3*4 = 24 and snake_case_name"))
+        #expect(!MarkdownSupport.looksLikeMarkdown("东京 - 大阪 的新干线"))
+        #expect(!MarkdownSupport.looksLikeMarkdown("a | b"))
+    }
+
+    @Test func rewritesImagesToPlaceholderLinks() {
+        let input = "看图 ![示意图](https://cdn.example.com/a.png \"title\") 结束"
+        let output = MarkdownSupport.rewriteImages(input)
+        #expect(!output.contains("!["))
+        #expect(output.contains("[🖼 示意图 · cdn.example.com](moepeek-image:"))
+        #expect(output.hasSuffix(") 结束"))
+    }
+
+    @Test func emptyAltFallsBackToImageLabel() {
+        let output = MarkdownSupport.rewriteImages("![](https://example.com/x.png)")
+        #expect(output.contains("🖼 "))
+        #expect(output.contains("example.com"))
+    }
+
+    @Test func placeholderURLRoundTrips() {
+        let original = "https://cdn.example.com/path/a b.png?x=1&y=2"
+        let rewritten = MarkdownSupport.rewriteImages("![a](\(original.replacingOccurrences(of: " ", with: "%20")))")
+        let start = rewritten.range(of: "(moepeek-image:")!.upperBound
+        let end = rewritten[start...].firstIndex(of: ")")!
+        let placeholder = URL(string: "moepeek-image:" + rewritten[start..<end])!
+        #expect(MarkdownSupport.imageURL(fromPlaceholder: placeholder)?.absoluteString
+            == original.replacingOccurrences(of: " ", with: "%20"))
+        #expect(MarkdownSupport.imageURL(fromPlaceholder: URL(string: "https://example.com")!) == nil)
+    }
+
+    @Test func hardensSingleLineBreaksBetweenPlainLines() {
+        #expect(MarkdownSupport.hardenLineBreaks("第一行\n第二行\n\n第三行") == "第一行  \n第二行\n\n第三行")
+    }
+
+    @Test func leavesBlockConstructsAlone() {
+        let list = "- a\n- b"
+        #expect(MarkdownSupport.hardenLineBreaks(list) == list)
+        let heading = "# 标题\n正文"
+        #expect(MarkdownSupport.hardenLineBreaks(heading) == heading)
+        let intro = "说明：\n- a"
+        #expect(MarkdownSupport.hardenLineBreaks(intro) == intro)
+        let fence = "```\nline1\nline2\n```"
+        #expect(MarkdownSupport.hardenLineBreaks(fence) == fence)
+    }
+
+    @Test func listItemContinuationGetsHardBreak() {
+        #expect(MarkdownSupport.hardenLineBreaks("- a\n续行") == "- a  \n续行")
+    }
+}

--- a/Tests/MarkdownSupportTests.swift
+++ b/Tests/MarkdownSupportTests.swift
@@ -19,29 +19,47 @@ import Testing
         #expect(!MarkdownSupport.looksLikeMarkdown("a | b"))
     }
 
-    @Test func rewritesImagesToPlaceholderLinks() {
-        let input = "看图 ![示意图](https://cdn.example.com/a.png \"title\") 结束"
-        let output = MarkdownSupport.rewriteImages(input)
-        #expect(!output.contains("!["))
-        #expect(output.contains("[🖼 示意图 · cdn.example.com](moepeek-image:"))
-        #expect(output.hasSuffix(") 结束"))
-    }
-
     @Test func emptyAltFallsBackToImageLabel() {
-        let output = MarkdownSupport.rewriteImages("![](https://example.com/x.png)")
-        #expect(output.contains("🖼 "))
-        #expect(output.contains("example.com"))
+        let segments = MarkdownSupport.renderingSegments("![](https://example.com/x.png)")
+        guard case .image(let placeholder) = segments.first else {
+            Issue.record("Expected an image rendering segment")
+            return
+        }
+        #expect(placeholder.label.hasPrefix("🖼 "))
+        #expect(placeholder.label.contains("example.com"))
+        #expect(placeholder.url == URL(string: "https://example.com/x.png")!)
     }
 
-    @Test func placeholderURLRoundTrips() {
-        let original = "https://cdn.example.com/path/a b.png?x=1&y=2"
-        let rewritten = MarkdownSupport.rewriteImages("![a](\(original.replacingOccurrences(of: " ", with: "%20")))")
-        let start = rewritten.range(of: "(moepeek-image:")!.upperBound
-        let end = rewritten[start...].firstIndex(of: ")")!
-        let placeholder = URL(string: "moepeek-image:" + rewritten[start..<end])!
-        #expect(MarkdownSupport.imageURL(fromPlaceholder: placeholder)?.absoluteString
-            == original.replacingOccurrences(of: " ", with: "%20"))
-        #expect(MarkdownSupport.imageURL(fromPlaceholder: URL(string: "https://example.com")!) == nil)
+    @Test func splitsImagesIntoDedicatedRenderingSegments() {
+        let input = """
+            ```swift
+            let message = "Hello"
+            ```
+
+            ![示意图](https://cdn.example.com/a.png)
+
+            结束
+            """
+
+        let segments = MarkdownSupport.renderingSegments(input)
+
+        #expect(segments.count == 3)
+        #expect(segments[0] == .markdown("```swift\nlet message = \"Hello\"\n```\n\n"))
+        #expect(segments[1] == .image(.init(
+            label: "🖼 示意图 · cdn.example.com",
+            url: URL(string: "https://cdn.example.com/a.png")!
+        )))
+        #expect(segments[2] == .markdown("\n\n结束"))
+    }
+
+    @Test func preservesEncodedImageURL() {
+        let original = "https://cdn.example.com/path/a%20b.png?x=1&y=2"
+        let segments = MarkdownSupport.renderingSegments("![a](\(original))")
+        guard case .image(let placeholder) = segments.first else {
+            Issue.record("Expected an image rendering segment")
+            return
+        }
+        #expect(placeholder.url.absoluteString == original)
     }
 
     @Test func hardensSingleLineBreaksBetweenPlainLines() {


### PR DESCRIPTION
## Summary

- Render completed Markdown responses with Textual while keeping streaming output as selectable plain text.
- Block remote image loading and replace Markdown images with native placeholder buttons that copy the original URL.
- Add a global Source/Markdown mode, a settings toggle, Swift Testing coverage, and release-time removal of unused math fonts.

<img width="1120" height="1300" alt="image" src="https://github.com/user-attachments/assets/c855603e-bb61-4422-8034-dde26aa9c874" />

## Changed files

- `Sources/UI/PopupPanel/`: add the Markdown result view and integrate it into provider result cards.
- `Sources/Utilities/`: add Markdown detection, line-break handling, image segmentation, and persisted view settings.
- `Sources/UI/Settings/` and `Resources/Localizable.xcstrings`: expose and localize the Markdown rendering preference.
- `Package.swift`, `Package.resolved`, and `Project.swift`: add Textual and the `MoePeekTests` target.
- `Tests/MarkdownSupportTests.swift`: cover detection, line breaks, image placeholders, ordering, and URL preservation.
- `.github/workflows/release.yml`, `README.md`, `README_zh.md`, and `CLAUDE.md`: strip unused math fonts during release and document platform/dependency/size changes.

## Testing

- `xcodebuild test -workspace MoePeek.xcworkspace -scheme MoePeek -derivedDataPath .build/acceptance-pr1/DerivedData CODE_SIGNING_ALLOWED=NO` — 8 tests passed.
- Verified the completed Markdown layout with a real OpenAI response: headings, hard line breaks, lists, emphasis, inline code, quote, fenced code, image placeholder, and normal link.
- Verified Source/Markdown switching, global mode persistence, and the settings fallback to plain text.
- Verified the image placeholder through native `AXPress`; the clipboard matched the original image URL exactly.
- Verified an unsigned archive after removing the math fonts; the signed archive remains covered by release CI credentials.

## ⚠️ Risk changes

- Raises the minimum deployment target from macOS 14 to macOS 15, which drops support for macOS 14 users.
- Adds Textual and its transitive SwiftUIMath dependency. The release workflow removes unused math font assets; the packaged app is expected to grow from roughly 5.7 MB to about 7 MB.

Closes #63
