### PR TITLE
chore: bump version to 0.18.1

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -50,7 +50,7 @@ let project = Project(
                     "CODE_SIGN_STYLE": "$(MOEPEEK_CODE_SIGN_STYLE)",
                     "CODE_SIGN_IDENTITY": "$(MOEPEEK_CODE_SIGN_IDENTITY)",
                     "DEVELOPMENT_TEAM": "$(MOEPEEK_DEVELOPMENT_TEAM)",
-                    "MARKETING_VERSION": "0.18.0",
+                    "MARKETING_VERSION": "0.18.1",
                     "CURRENT_PROJECT_VERSION": "1",
                 ],
                 configurations: [


### PR DESCRIPTION
Prepares the v0.18.1 patch release. Ships the web image placeholder fix from #88.